### PR TITLE
Make skip() and limit() also accept closures

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -266,23 +266,31 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Returns a new stream with only the first `n` elements
    *
-   * @param  int $n
+   * @param  var $arg either an integer or a closure
    * @return self<T>
    */
   #[@generic(return= 'self<T>')]
-  public function limit($n) {
-    return new self(new \LimitIterator($this->getIterator(), 0, $n));
+  public function limit($arg) {
+    if (is_numeric($arg)) {
+      return new self(new \LimitIterator($this->getIterator(), 0, (int)$arg));
+    } else {
+      return new self(new Window($this->getIterator(), function() { return false; }, Closure::of($arg)));
+    }
   }
 
   /**
    * Returns a new stream with only the first `n` elements
    *
-   * @param  int $n
+   * @param  var $arg either an integer or a closure
    * @return self<T>
    */
   #[@generic(return= 'self<T>')]
-  public function skip($n) {
-    return new self(new \LimitIterator($this->getIterator(), $n, -1));
+  public function skip($arg) {
+    if (is_numeric($arg)) {
+      return new self(new \LimitIterator($this->getIterator(), (int)$arg, -1));
+    } else {
+      return new self(new Window($this->getIterator(), Closure::of($arg), function() { return false; }));
+    }
   }
 
   /**

--- a/src/main/php/util/data/Window.class.php
+++ b/src/main/php/util/data/Window.class.php
@@ -1,0 +1,69 @@
+<?php namespace util\data;
+
+/**
+ * A window is an iterator that skips elements from an underlying
+ * iterator that match its "skip" closure, then returns elements
+ * until its "stop" closure is reached.
+ *
+ * @see   php://LimitIterator but uses closures and not just offsets
+ * @test  xp://util.data.unittest.WindowTest
+ */
+class Window extends \lang\Object implements \Iterator {
+  protected $it;
+  protected $skip;
+  protected $stop;
+  protected $valid;
+
+  /**
+   * Creates a new Mapper instance
+   *
+   * @param  php.Iterator $it
+   * @param  php.Closure $skip
+   * @param  php.Closure $stop
+   */
+  public function __construct(\Iterator $it, \Closure $skip, \Closure $stop) {
+    $this->it= $it;
+    $this->skip= $skip;
+    $this->stop= $stop;
+  }
+
+  /** @return void */
+  public function rewind() {
+    $this->it->rewind();
+    $this->valid= true;
+    while ($this->valid()) {
+      $current= $this->it->current();
+      $skip= $this->skip->__invoke($current);
+      if ($this->stop->__invoke($current)) {
+        $this->valid= false;
+      } else if ($skip) {
+        $this->it->next();
+        continue;
+      }
+      break;
+    }
+  }
+
+  /** @return var */
+  public function current() {
+    return $this->it->current();
+  }
+
+  /** @return var */
+  public function key() {
+    return $this->it->key();
+  }
+
+  /** @return void */
+  public function next() {
+    $this->it->next();
+    if ($this->stop->__invoke($this->it->current())) {
+      $this->valid= false;
+    }
+  }
+
+  /** @return bool */
+  public function valid() {
+    return $this->valid && $this->it->valid();
+  }
+}

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -253,6 +253,11 @@ class SequenceTest extends AbstractSequenceTest {
   }
 
   #[@test]
+  public function limit_stops_when_given_closure_returns_true() {
+    $this->assertSequence([1, 2], Sequence::of([1, 2, 3, 4])->limit(function($e) { return $e > 2; }));
+  }
+
+  #[@test]
   public function concat() {
     $this->assertSequence([1, 2, 3, 4], Sequence::concat(Sequence::of([1, 2]), Sequence::of([3, 4])));
   }
@@ -260,6 +265,11 @@ class SequenceTest extends AbstractSequenceTest {
   #[@test]
   public function skip_excludes_n_first_elements() {
     $this->assertSequence([3, 4], Sequence::of([1, 2, 3, 4])->skip(2));
+  }
+
+  #[@test]
+  public function skip_excludes_elements_when_given_closure_returns_true() {
+    $this->assertSequence([3, 4], Sequence::of([1, 2, 3, 4])->skip(function($e) { return $e < 3; }));
   }
 
   #[@test, @values([

--- a/src/test/php/util/data/unittest/WindowTest.class.php
+++ b/src/test/php/util/data/unittest/WindowTest.class.php
@@ -1,0 +1,88 @@
+<?php namespace util\data\unittest;
+
+use util\data\Window;
+
+class WindowTest extends \unittest\TestCase {
+  protected static $fixture= [1, 2, 3, 4, 5];
+
+  /**
+   * Returns a window on values with a given skip and stop function using the CUT.
+   *
+   * @param  var[] $values
+   * @param  function<var: bool> $skip
+   * @param  function<var: bool> $stop
+   * @return var[]
+   */
+  protected function window($values, $skip, $stop) {
+    $result= [];
+    foreach (new Window(new \ArrayIterator($values), $skip, $stop) as $val) {
+      $result[]= $val;
+    }
+    return $result;
+  }
+
+  #[@test]
+  public function works_with_empty_input() {
+    $this->assertEquals([], $this->window(
+      [],
+      function($e) { return false; },
+      function($e) { return false; }
+    ));
+  }
+
+  #[@test]
+  public function returns_complete_input_when_both_skip_and_stop_return_false() {
+    $this->assertEquals(self::$fixture, $this->window(
+      self::$fixture,
+      function($e) { return false; },
+      function($e) { return false; }
+    ));
+  }
+
+  #[@test]
+  public function does_not_return_elements_skipped() {
+    $this->assertEquals([3, 4, 5], $this->window(
+      self::$fixture,
+      function($e) { return $e < 3; },
+      function($e) { return false; }
+    ));
+  }
+
+  #[@test]
+  public function does_not_return_elements_after_stopped() {
+    $this->assertEquals([1, 2, 3], $this->window(
+      self::$fixture,
+      function($e) { return false; },
+      function($e) { return $e > 3; }
+    ));
+  }
+
+  #[@test]
+  public function skips_and_stops() {
+    $this->assertEquals([3], $this->window(
+      self::$fixture,
+      function($e) { return $e < 3; },
+      function($e) { return $e > 3; }
+    ));
+  }
+
+  #[@test]
+  public function returns_empty_when_stop_returns_true_before_skip_is_true() {
+    $this->assertEquals([], $this->window(
+      self::$fixture,
+      function($e) { return $e < 3; },
+      function($e) { return $e > 0; }
+    ));
+  }
+
+  #[@test]
+  public function skip_and_stop_invocations() {
+    $invocations= ['skip' => [], 'stop' => []];
+    $this->window(
+      self::$fixture,
+      function($e) use(&$invocations) { $invocations['skip'][]= $e; return $e < 3; },
+      function($e) use(&$invocations) { $invocations['stop'][]= $e; return $e > 3; }
+    );
+    $this->assertEquals(['skip' => [1, 2, 3], 'stop' => [1, 2, 3, 4]], $invocations);
+  }
+}


### PR DESCRIPTION
This pull request enables the use of closures as arguments to skip() and limit():
### skip

The following example returns [3, 4].

``` php
Sequence::of([1, 2, 3, 4])->skip(function($e) { return $e < 3; });
```
### limit

The following example returns [1, 2]. The underlying iterator is stopped after 3 is returned.

``` php
Sequence::of([1, 2, 3, 4])->limit(function($e) { return $e > 2; });
```

/cc @mikey179
