### PR TITLE
Implement Sequence::toMap()

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -158,6 +158,22 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
+   * Collects all elements in a map
+   *
+   * @return [:var]
+   * @throws lang.IllegalArgumentException if streamed and invoked more than once
+   */
+  public function toMap() {
+    return $this->terminal(function() {
+      $return= [];
+      foreach ($this->elements as $key => $element) {
+        $return[$key]= $element;
+      }
+      return $return;
+    });
+  }
+
+  /**
    * Counts all elements
    *
    * @return int

--- a/src/test/php/util/data/unittest/EnumerationTest.class.php
+++ b/src/test/php/util/data/unittest/EnumerationTest.class.php
@@ -4,13 +4,22 @@ use util\data\Enumeration;
 
 class EnumerationTest extends \unittest\TestCase {
 
-  #[@test, @values('util.data.unittest.Enumerables::valid')]
-  public function all_in($enumerable, $desc) {
+  #[@test, @values('util.data.unittest.Enumerables::validArrays')]
+  public function all_in_array($enumerable, $desc) {
     $result= [];
     foreach (Enumeration::of($enumerable) as $value) {
       $result[]= $value;
     }
     $this->assertEquals([1, 2, 3], $result, $desc);
+  }
+
+  #[@test, @values('util.data.unittest.Enumerables::validMaps')]
+  public function all_in_map($enumerable, $desc) {
+    $result= [];
+    foreach (Enumeration::of($enumerable) as $key => $value) {
+      $result[$key]= $value;
+    }
+    $this->assertEquals(['color' => 'green', 'price' => 12.99], $result, $desc);
   }
 
   #[@test, @values('util.data.unittest.Enumerables::invalid'), @expect('lang.IllegalArgumentException')]

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -5,17 +5,51 @@ use util\cmd\Console;
 use util\data\Sequence;
 use util\data\Optional;
 use util\data\Collector;
+use lang\IllegalStateException;
 
 class SequenceTest extends AbstractSequenceTest {
+
+  /**
+   * Assertion helper
+   *
+   * @param  util.data.Sequence $seq
+   * @param  function(var): void $func
+   * @return void
+   * @throws unittest.AssertionFailedError
+   */
+  protected function assertNotTwice($seq, $func) {
+    $func($seq);
+    try {
+      $func($seq);
+      $this->fail('No exception raised', null, 'lang.IllegalStateException');
+    } catch (IllegalStateException $expected) {
+      // OK
+    }
+  }
 
   #[@test]
   public function empty_sequence() {
     $this->assertSequence([], Sequence::$EMPTY);
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::valid')]
+  #[@test]
+  public function toArray_for_empty_sequence() {
+    $this->assertEquals([], Sequence::$EMPTY->toArray());
+  }
+
+  #[@test, @values('util.data.unittest.Enumerables::validArrays')]
   public function toArray_returns_elements_as_array($input, $name) {
     $this->assertSequence([1, 2, 3], Sequence::of($input), $name);
+  }
+
+  #[@test]
+  public function toMap_for_empty_sequence() {
+    $this->assertEquals([], Sequence::$EMPTY->toMap());
+  }
+
+  #[@test, @values('util.data.unittest.Enumerables::validMaps')]
+  public function toMap_returns_elements_as_map($input) {
+    $this->assertEquals(['color' => 'green', 'price' => 12.99], Sequence::of($input)->toMap());
   }
 
   #[@test, @values([
@@ -94,59 +128,49 @@ class SequenceTest extends AbstractSequenceTest {
     $this->assertEquals(sizeof($input), $i);
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::fixed')]
+  #[@test, @values('util.data.unittest.Enumerables::fixedArrays')]
   public function may_use_sequence_based_on_a_fixed_enumerable_more_than_once($input) {
     $seq= Sequence::of($input);
     $seq->toArray();
     $seq->toArray();
   }
 
-  protected function assertNotTwice($seq, $func) {
-    $func($seq);
-    try {
-      $func($seq);
-      $this->fail('No exception raised', null, 'lang.IllegalStateException');
-    } catch (\lang\IllegalStateException $expected) {
-      // OK
-    }
-  }
-
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_toArray_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->toArray(); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_each_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->each('typeof'); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_first_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->first(); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_count_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->count(); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_sum_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->sum(); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_min_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->min(); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_max_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->max(); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_collect_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->collect(new Collector(
       function() { return 0; },
@@ -154,7 +178,7 @@ class SequenceTest extends AbstractSequenceTest {
     )); });
   }
 
-  #[@test, @values('util.data.unittest.Enumerables::streamed')]
+  #[@test, @values('util.data.unittest.Enumerables::streamedArrays')]
   public function cannot_use_reduce_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->reduce(
       0,


### PR DESCRIPTION
This PR implements `[:var] Sequence::toMap()`, to complement `var[] Sequence::toArray()` and in contrast to `Collectors::toMap()`, which returns a `util.collections.Map`.