### PR TITLE
Implement Sequence::grouped()

### DIFF
--- a/src/main/php/util/data/Grouping.class.php
+++ b/src/main/php/util/data/Grouping.class.php
@@ -1,0 +1,63 @@
+<?php namespace util\data;
+
+/**
+ * A grouping returns elements in groups of a given size, and is the opposite
+ * of flattening a list of grouos.
+ *
+ * @test  xp://util.data.unittest.SequenceGroupingTest
+ */
+class Grouping extends \lang\Object implements \Iterator {
+  protected $it, $size, $key, $current, $valid;
+
+  /**
+   * Creates a new Grouping instance
+   *
+   * @param  php.Iterator $it
+   * @param  int $size
+   */
+  public function __construct(\Iterator $it, $size) {
+    $this->it= $it;
+    $this->size= $size;
+  }
+
+  /** @return var[] */
+  public function group() {
+    $this->valid= $this->it->valid();
+
+    for ($group= [], $i= 0; $i < $this->size && $this->it->valid(); $i++) {
+      $key= $this->it->key();
+      $group[is_int($key) ? $i : $key]= $this->it->current();
+      $this->it->next();
+    }
+
+    return $group;
+  }
+
+  /** @return void */
+  public function rewind() {
+    $this->it->rewind();
+    $this->current= $this->group();
+    $this->key= 0;
+  }
+
+  /** @return var */
+  public function current() {
+    return $this->current;
+  }
+
+  /** @return var */
+  public function key() {
+    return $this->key;
+  }
+
+  /** @return void */
+  public function next() {
+    $this->current= $this->group();
+    $this->key++;
+  }
+
+  /** @return bool */
+  public function valid() {
+    return $this->valid;
+  }
+}

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -425,6 +425,18 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
+   * Returns a new stream which consists of groups by a given size. The last group
+   * may be smaller than the given size!
+   *
+   * @param  int $size
+   * @return self
+   * @throws lang.IllegalArgumentException
+   */
+  public function grouped($size) {
+    return new self(new Grouping($this->getIterator(), $size));
+  }
+
+  /**
    * Returns a new stream which additionally calls the given function for 
    * each element it consumes. Use this e.g. for debugging purposes.
    *

--- a/src/test/php/util/data/unittest/SequenceGroupingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceGroupingTest.class.php
@@ -1,0 +1,38 @@
+<?php namespace util\data\unittest;
+
+use util\data\Sequence;
+
+class SequenceGroupingTest extends AbstractSequenceTest {
+
+  #[@test]
+  public function empty_in_groups_of_three() {
+    $this->assertSequence([], Sequence::$EMPTY->grouped(3));
+  }
+
+  #[@test, @values([
+  #  [[1]], [['one' => 1]],
+  #  [[1, 2]], [['one' => 1, 'two' => 2]],
+  #  [[1, 2, 3]], [['one' => 1, 'two' => 2, 'three' => 3]]
+  #])]
+  public function less_than_or_equal_to_three_in_groups_of_three($in) {
+    $this->assertSequence([$in], Sequence::of($in)->grouped(3));
+  }
+
+  #[@test]
+  public function six_in_groups_of_three() {
+    $this->assertSequence([[1, 2, 3], [4, 5, 6]], Sequence::of([1, 2, 3, 4, 5, 6])->grouped(3));
+  }
+
+  #[@test]
+  public function seven_in_groups_of_three() {
+    $this->assertSequence([[1, 2, 3], [4, 5, 6], [7]], Sequence::of([1, 2, 3, 4, 5, 6, 7])->grouped(3));
+  }
+
+  #[@test]
+  public function four_in_groups_of_three_with_keys() {
+    $this->assertSequence(
+      [['one' => 1, 'two' => 2, 'three' => 3], ['four' => 4]],
+      Sequence::of(['one' => 1, 'two' => 2, 'three' => 3, 'four' => 4])->grouped(3)
+    );
+  }
+}


### PR DESCRIPTION
This PR implements a `grouped()` method which returns groups of a given size from the input:

``` php
 // For arrays: [[1, 2, 3], [4, 5, 6], [7]]
Sequence::of([1, 2, 3, 4, 5, 6, 7])->grouped(3)

// For maps: [['one' => 1, 'two' => 2], ['three' => 3]]
Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->grouped(2)
```
