### PR TITLE
Implement variant of Sequence::each() which iterates elements w/o callback

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -300,37 +300,35 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @return int The number of elements
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
-  public function each($consumer, $args= null) {
+  public function each($consumer= null, $args= null) {
     if (null !== $args) {
       $t= function() use($consumer, $args) {
         $inv= Closure::$APPLY->newInstance($consumer);
         $i= 0;
-        foreach ($this->elements as $element) {
-          call_user_func_array($inv, array_merge([$element], $args));
-          $i++;
-        }
+        foreach ($this->elements as $element) { call_user_func_array($inv, array_merge([$element], $args)); $i++; }
         return $i;
       };
     } else if (Closure::$APPLY_WITH_KEY->isInstance($consumer)) {
       $t= function() use($consumer) {
         $inv= Closure::$APPLY_WITH_KEY->cast($consumer);
         $i= 0;
-        foreach ($this->elements as $key => $element) {
-          $inv($element, $key);
-          $i++;
-        }
+        foreach ($this->elements as $key => $element) { $inv($element, $key); $i++; }
         return $i;
       };
-    } else {
+    } else if (null !== $consumer) {
       $t= function() use($consumer) {
         $inv= Closure::$APPLY->newInstance($consumer);
         $i= 0;
-        foreach ($this->elements as $element) {
-          $inv($element);
-          $i++;
-        }
+        foreach ($this->elements as $element) { $inv($element); $i++; }
         return $i;
       };
+    } else {
+      $t= function() {
+        $i= 0;
+        foreach ($this->elements as $element) { $i++; }
+        return $i;
+      };
+
     }
     return $this->terminal($t);
   }

--- a/src/test/php/util/data/unittest/EachTest.class.php
+++ b/src/test/php/util/data/unittest/EachTest.class.php
@@ -3,8 +3,14 @@
 use util\data\Sequence;
 use io\streams\MemoryOutputStream;
 use util\cmd\Console;
+use lang\IllegalArgumentException;
 
 class EachTest extends AbstractSequenceTest {
+
+  /** @return var[][] */
+  protected function invalidArguments() {
+    return array_filter($this->noncallables(), function($args) { return null !== $args[0]; });
+  }
 
   #[@test]
   public function each() {
@@ -25,8 +31,13 @@ class EachTest extends AbstractSequenceTest {
   }
 
   #[@test, @values([[[1, 2, 3, 4]], [[]]])]
-  public function returns_number_of_processed_elements($input) {
+  public function returns_number_of_processed_elements_with_func($input) {
     $this->assertEquals(sizeof($input), Sequence::of($input)->each(function($e) { }));
+  }
+
+  #[@test, @values([[[1, 2, 3, 4]], [[]]])]
+  public function returns_number_of_processed_elements_with_null($input) {
+    $this->assertEquals(sizeof($input), Sequence::of($input)->each());
   }
 
   #[@test]
@@ -61,8 +72,13 @@ class EachTest extends AbstractSequenceTest {
     $this->assertEquals('1234', $bytes);
   }
 
-  #[@test, @values('noncallables'), @expect('lang.IllegalArgumentException')]
+  #[@test, @values('invalidArguments'), @expect('lang.IllegalArgumentException')]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->each($noncallable);
+  }
+
+  #[@test, @expect('lang.IllegalArgumentException')]
+  public function raises_exception_when_given_null_and_args() {
+    Sequence::of([])->each(null, []);
   }
 }

--- a/src/test/php/util/data/unittest/PeekTest.class.php
+++ b/src/test/php/util/data/unittest/PeekTest.class.php
@@ -17,7 +17,7 @@ class PeekTest extends AbstractSequenceTest {
     Sequence::of([1, 2, 3, 4])
       ->filter(function($e) { return $e % 2 > 0; })
       ->peek(function($e) use(&$debug) { $debug[]= $e; })
-      ->toArray()   // or any other terminal action
+      ->each()
     ;
     $this->assertEquals([1, 3], $debug);
   }
@@ -28,7 +28,7 @@ class PeekTest extends AbstractSequenceTest {
     Sequence::of([1, 2, 3, 4])
       ->filter(function($e) { return $e % 2 > 0; })
       ->peek(function($e, $key) use(&$debug) { $debug[]= $key; })
-      ->toArray()   // or any other terminal action
+      ->each()
     ;
     $this->assertEquals([0, 2], $debug);
   }
@@ -39,7 +39,7 @@ class PeekTest extends AbstractSequenceTest {
     $out= new MemoryOutputStream();
     Console::$out->setStream($out);
 
-    Sequence::of([1, 2, 3, 4])->peek('util.cmd.Console::write')->toArray();
+    Sequence::of([1, 2, 3, 4])->peek('util.cmd.Console::write')->each();
 
     Console::$out->setStream($orig);    
     $this->assertEquals('1234', $out->getBytes());
@@ -49,7 +49,7 @@ class PeekTest extends AbstractSequenceTest {
   public function with_var_export() {
     ob_start();
 
-    Sequence::of([1, 2, 3, 4])->peek('var_export', $args= [false])->toArray();
+    Sequence::of([1, 2, 3, 4])->peek('var_export', $args= [false])->each();
 
     $bytes= ob_get_contents();
     ob_end_clean();

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -36,14 +36,14 @@ class SequenceFilteringTest extends AbstractSequenceTest {
   #[@test]
   public function array_index_is_passed_to_function() {
     $keys= [];
-    Sequence::of([1, 2, 3])->filter(function($e, $key) use(&$keys) { $keys[]= $key; return true; })->toArray();
+    Sequence::of([1, 2, 3])->filter(function($e, $key) use(&$keys) { $keys[]= $key; return true; })->each();
     $this->assertEquals([0, 1, 2], $keys);
   }
 
   #[@test]
   public function map_key_is_passed_to_function() {
     $keys= [];
-    Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->filter(function($e, $key) use(&$keys) { $keys[]= $key; return true; })->toArray();
+    Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->filter(function($e, $key) use(&$keys) { $keys[]= $key; return true; })->each();
     $this->assertEquals(['one', 'two', 'three'], $keys);
   }
 }

--- a/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
@@ -34,14 +34,14 @@ class SequenceFlatteningTest extends AbstractSequenceTest {
   #[@test]
   public function array_index_is_passed_to_function() {
     $keys= [];
-    Sequence::of([['a', 'b'], ['c', 'd']])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->toArray();
+    Sequence::of([['a', 'b'], ['c', 'd']])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
     $this->assertEquals([0, 1], $keys);
   }
 
   #[@test]
   public function map_key_is_passed_to_function() {
     $keys= [];
-    Sequence::of(['one' => [1], 'two' => [2], 'three' => [3]])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->toArray();
+    Sequence::of(['one' => [1], 'two' => [2], 'three' => [3]])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
     $this->assertEquals(['one', 'two', 'three'], $keys);
   }
 }

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -22,14 +22,14 @@ class SequenceMappingTest extends AbstractSequenceTest {
   #[@test]
   public function array_index_is_passed_to_function() {
     $keys= [];
-    Sequence::of([1, 2, 3])->map(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->toArray();
+    Sequence::of([1, 2, 3])->map(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
     $this->assertEquals([0, 1, 2], $keys);
   }
 
   #[@test]
   public function map_key_is_passed_to_function() {
     $keys= [];
-    Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->map(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->toArray();
+    Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->map(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
     $this->assertEquals(['one', 'two', 'three'], $keys);
   }
 }

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -90,15 +90,15 @@ class SequenceTest extends AbstractSequenceTest {
   #[@test, @values([[['a', 'b', 'c', 'd']], [[]]])]
   public function counting($input) {
     $i= 0;
-    Sequence::of($input)->counting($i)->toArray();
+    Sequence::of($input)->counting($i)->each();
     $this->assertEquals(sizeof($input), $i);
   }
 
   #[@test, @values('util.data.unittest.Enumerables::fixed')]
   public function may_use_sequence_based_on_a_fixed_enumerable_more_than_once($input) {
     $seq= Sequence::of($input);
-    $seq->toArray();
-    $seq->toArray();
+    $seq->each();
+    $seq->each();
   }
 
   protected function assertNotTwice($seq, $func) {
@@ -118,7 +118,7 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test, @values('util.data.unittest.Enumerables::streamed')]
   public function cannot_use_each_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
-    $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->each('typeof'); });
+    $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->each(); });
   }
 
   #[@test, @values('util.data.unittest.Enumerables::streamed')]


### PR DESCRIPTION
This is a more memory-efficient than calling toArray() and discarding the results
