### PR TITLE
Implement Sequence::sliding()

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -418,6 +418,19 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
     return new self(new Flattener($it));
   }
 
+  /*
+   * Returns a new stream which consists of slides by a given size. The first
+   * (and only) group will be smaller only if the sequence contains less than
+   * the given size elements.
+   * 
+   * @param  int $size 
+   * @return self 
+   * @throws lang.IllegalArgumentException 
+   */ 
+  public function sliding($size) { 
+    return new self(new Sliding($this->getIterator(), $size)); 
+  } 
+
   /**
    * Returns a new stream which additionally calls the given function for 
    * each element it consumes. Use this e.g. for debugging purposes.

--- a/src/main/php/util/data/Sliding.class.php
+++ b/src/main/php/util/data/Sliding.class.php
@@ -1,0 +1,63 @@
+<?php namespace util\data;
+
+/**
+ * A sliding returns elements in overlapping groups of a given size.
+ *
+ * @test  xp://util.data.unittest.SequenceSlidingTest
+ */
+class Sliding extends \lang\Object implements \Iterator {
+  protected $it, $size, $key, $group, $valid;
+
+  /**
+   * Creates a new Grouping instance
+   *
+   * @param  php.Iterator $it
+   * @param  int $size
+   */
+  public function __construct(\Iterator $it, $size) {
+    $this->it= $it;
+    $this->size= $size;
+    $this->group= [];
+  }
+
+  /** @return voud */
+  public function fill() {
+    $this->valid= $this->it->valid();
+
+    for ($i= sizeof($this->group); $i < $this->size && $this->it->valid(); $i++) {
+      $key= $this->it->key();
+      $this->group[is_int($key) ? $i : $key]= $this->it->current();
+      $this->it->next();
+    }
+  }
+
+  /** @return void */
+  public function rewind() {
+    $this->it->rewind();
+    $this->fill();
+    $this->key= 0;
+  }
+
+  /** @return var */
+  public function current() {
+    return $this->group;
+  }
+
+  /** @return var */
+  public function key() {
+    return $this->key;
+  }
+
+  /** @return void */
+  public function next() {
+    array_shift($this->group);
+    $this->fill();
+    $this->key++;
+  }
+
+  /** @return bool */
+  public function valid() {
+    return $this->valid;
+  }
+}
+

--- a/src/test/php/util/data/unittest/SequenceSlidingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSlidingTest.class.php
@@ -1,0 +1,35 @@
+<?php namespace util\data\unittest;
+
+use util\data\Sequence;
+
+class SequenceSlidingTest extends AbstractSequenceTest {
+
+  #[@test]
+  public function empty_in_slides_of_three() {
+    $this->assertSequence([], Sequence::$EMPTY->sliding(3));
+  }
+
+  #[@test, @values([
+  #  [[1]],
+  #  [[1, 2]],
+  #  [[1, 2, 3]]
+  #])]
+  public function less_than_or_equal_to_three_in_slides_of_three($value) {
+    $this->assertSequence([$value], Sequence::of($value)->sliding(3));
+  }
+
+  #[@test]
+  public function three_in_slides_of_three() {
+    $this->assertSequence([[1, 2, 3]], Sequence::of([1, 2, 3])->sliding(3));
+  }
+
+  #[@test]
+  public function four_in_slides_of_three() {
+    $this->assertSequence([[1, 2, 3], [2, 3, 4]], Sequence::of([1, 2, 3, 4])->sliding(3));
+  }
+
+  #[@test]
+  public function six_in_slides_of_three() {
+    $this->assertSequence([[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6]], Sequence::of([1, 2, 3, 4, 5, 6])->sliding(3));
+  }
+}


### PR DESCRIPTION
This PR implements a `sliding()` method which returns groups of a given size from the input:

``` php
 // For arrays: [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6], [5, 6, 7]]
Sequence::of([1, 2, 3, 4, 5, 6, 7])->sliding(3)
```

This can be used to calculate [moving averages](https://en.wikipedia.org/wiki/Moving_average)
