### PR TITLE
Add optional matching to first()

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -131,16 +131,22 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
         throw new IllegalStateException('Generator closed');
       }
 
-      if ($matching) {
-        $match= Closure::of($matching);
-        foreach ($this->elements as $element) {
-          $gen && $this->elements->closed= true;
-          if ($match($element)) return Optional::of($element);
-        }
-      } else {
+      if (null === $matching) {
         foreach ($this->elements as $element) {
           $gen && $this->elements->closed= true;
           return Optional::of($element);
+        }
+      } else if (Closure::$APPLY_WITH_KEY->isInstance($matching)) {
+        $match= Closure::$APPLY_WITH_KEY->cast($matching);
+        foreach ($this->elements as $key => $element) {
+          $gen && $this->elements->closed= true;
+          if ($match($element, $key)) return Optional::of($element);
+        }
+      } else {
+        $match= Closure::$APPLY->newInstance($matching);
+        foreach ($this->elements as $element) {
+          $gen && $this->elements->closed= true;
+          if ($match($element)) return Optional::of($element);
         }
       }
       return Optional::$EMPTY;

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -56,6 +56,11 @@ class SequenceTest extends AbstractSequenceTest {
     $this->assertEquals(2, Sequence::of([1, 2, 3])->first(function($e) { return $e % 2 === 0; })->get());
   }
 
+  #[@test]
+  public function first_with_filter_and_key() {
+    $this->assertEquals(2, Sequence::of(['a' => 1, 'b' => 2])->first(function($e, $key) { return 'b' === $key; })->get());
+  }
+
   #[@test, @values([
   #  [[1, 2, 3], [1, 2, 2, 3, 1, 3]],
   #  [[new String('a'), new String('b')], [new String('a'), new String('a'), new String('b')]]


### PR DESCRIPTION
This PR adds an optional parameter to `Sequence::first()` to match. Basically, `first($f)` is a shorthand for `filter($f)->first()`.

``` php
Sequence::of([1, 2, 3])->first()->get();                                       // 1
Sequence::of([1, 2, 3])->first(function($e) { return $e % 2 === 0; })->get();  // 2
```
