### PR TITLE
Use Composer to fetch dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@ before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
   - composer install
   - echo "vendor/autoload.php" > composer.pth
-  - echo "use=vendor/xp-framework/core" >> xp.ini
+  - echo "use=vendor/xp-framework/core" > xp.ini
   - echo "[runtime]" >> xp.ini
   - echo "date.timezone=Europe/Berlin" >> xp.ini
-  - cat xp.ini
-  - find vendor
 
 script:
   - ./unittest src/test/php

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_script:
   - echo "use=vendor/xp-framework/core" >> xp.ini
   - echo "[runtime]" >> xp.ini
   - echo "date.timezone=Europe/Berlin" >> xp.ini
+  - cat xp.ini
+  - find vendor
 
 script:
   - ./unittest src/test/php

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
-  - composer install
+  - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
   - echo "use=vendor/xp-framework/core" > xp.ini
   - echo "[runtime]" >> xp.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ matrix:
 
 before_script:
   - wget 'https://github.com/xp-framework/xp-runners/releases/download/v5.2.0/setup' -O - | php
-  - wget 'https://github.com/xp-framework/core/archive/master.zip' -O depend.zip ; unzip -d depend depend.zip
-  - find depend -type d -name php > depend.pth
+  - composer install
+  - echo "vendor/autoload.php" > composer.pth
+  - echo "use=vendor/xp-framework/core" >> xp.ini
   - echo "[runtime]" >> xp.ini
   - echo "date.timezone=Europe/Berlin" >> xp.ini
 


### PR DESCRIPTION
This PR changes dependency management to use Composer.

The general recipe for using Composer and the XP runners is:

* Download XP runners
* Execute `composer install`
* Add a line containing `vendor/autoload.php` to the `composer.pth`
* Set XP use path, e.g. via `use=vendor/xp-framework/core` inside `xp.ini`
* :white_check_mark: ***Done***