### PR TITLE
Implement Collectors::toPivot(), which returns a util.data.Pivot instance

### DIFF
--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -72,6 +72,15 @@ final class Collectors extends \lang\Object {
   }
 
   /**
+   * Creates a new collector gathering the elements in a pivot table
+   *
+   * @return util.data.ICollector
+   */
+  public static function toPivot() {
+    return new PivotCollector();
+  }
+
+  /**
    * Creates a new collector gathering the elements in a map.
    *
    * @param  function(var): var $classifier

--- a/src/main/php/util/data/Pivot.class.php
+++ b/src/main/php/util/data/Pivot.class.php
@@ -7,20 +7,20 @@ use lang\IllegalArgumentException;
  * =====
  *
  * ```
- * .------------------------------------------------------------------------.
- * | Category  | 2015-05-10 | 2015-05-11 | Sum      | Percentage   | Avg.   |
- * |-----------|------------|------------|----------|--------------|--------|
- * | OK        | n:100      | n:95       | n:195    | n:97.5%      | n:97.5 |
- * | GOOD      | n:2        | n:0        | n:2      | n:1.0%       | n:1    |
- * | ERROR     | n:0        | n:3        | n:3      | n:1.5%       | n:1.5  |
- * | ^- client | ^- n:0     | ^- n:2     | ^- n:2   | ^- n:1.0%    | n:1    |
- * |   ^- 403  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5%  | n:0.5  |
- * |   ^- 404  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5%  | n:0.5  |
- * | ^- server | ^- n:0     | ^- n:1     | ^- n:1   | ^- n:0.5%    | n:0.5  |
- * |   ^- 500  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5%  | n:0.5  |
- * |-----------|------------|------------|----------|--------------|--------|
- * | Total     | n:102      | n:98       | n:200    |              |        |
- * `------------------------------------------------------------------------´
+ * .-----------------------------------------------------------------------------.
+ * | Category  | 2015-05-10 | 2015-05-11 | Sum      | Percentage | Count | Avg.   |
+ * |-----------|------------|------------|----------|------------|-------|--------|
+ * | OK        | n:100      | n:95       | n:195    | n:97.5     | n:2   | n:97.5 |
+ * | GOOD      | n:2        | n:0        | n:2      | n:1.0      | n:1   | n:2    |
+ * | ERROR     | n:0        | n:3        | n:3      | n:1.5      | n:3   | n:1.0  |
+ * | ^- client | ^- n:0     | ^- n:2     | ^- n:2   | ^- n:1.0   | n:3   | n:0.67 |
+ * |   ^- 403  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5 | n:1   | n:1.0  |
+ * |   ^- 404  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5 | n:2   | n:0.5  |
+ * | ^- server | ^- n:0     | ^- n:1     | ^- n:1   | ^- n:0.5   | n:1   | n:0.5  |
+ * |   ^- 500  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5 | n:1   | n:0.5  |
+ * |-----------|------------|------------|----------|------------|-------|--------|
+ * | Total     | n:102      | n:98       | n:200    |            | n:14  |        |
+ * `-----------------------------------------------------------------------------´
  * ```
  *
  * Accessing by category
@@ -28,7 +28,8 @@ use lang\IllegalArgumentException;
  * Use the `sum()`, `average()` and `percentage()` methods to access the values.
  * In the above example, `sum("OK")['n']` = 195, `average("ERROR")['n']` = 1.5
  * and `percentage("GOOD")['n']` = 1.0. The subtotals e.g. for client errors can
- * be accessed by passing in varargs: `sum("ERROR", "client")['n']` = 2.
+ * be accessed by passing in varargs: `sum("ERROR", "client")['n']` = 2. The number
+ * of records included in the fact is returned by `count("OK")` = 2.
  *
  * To iterate over the categories, use the `rows()` method.
  *
@@ -43,7 +44,7 @@ use lang\IllegalArgumentException;
  * Use the `total()` method without any argument to access the grand total for all
  * values (`['n' => 200]`).
  *
- * The `count()` method will return how many columns we spread on (2).
+ * The `count()` method will return many records we processed on (14).
  *
  * @test  xp://util.data.unittest.PivotTest
  */

--- a/src/main/php/util/data/Pivot.class.php
+++ b/src/main/php/util/data/Pivot.class.php
@@ -1,0 +1,207 @@
+<?php namespace util\data;
+
+use lang\IllegalArgumentException;
+
+/**
+ * Pivot
+ * =====
+ *
+ * ```
+ * .------------------------------------------------------------------------.
+ * | Category  | 2015-05-10 | 2015-05-11 | Sum      | Percentage   | Avg.   |
+ * |-----------|------------|------------|----------|--------------|--------|
+ * | OK        | n:100      | n:95       | n:195    | n:97.5%      | n:97.5 |
+ * | GOOD      | n:2        | n:0        | n:2      | n:1.0%       | n:1    |
+ * | ERROR     | n:0        | n:3        | n:3      | n:1.5%       | n:1.5  |
+ * | ^- client | ^- n:0     | ^- n:2     | ^- n:2   | ^- n:1.0%    | n:1    |
+ * |   ^- 403  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5%  | n:0.5  |
+ * |   ^- 404  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5%  | n:0.5  |
+ * | ^- server | ^- n:0     | ^- n:1     | ^- n:1   | ^- n:0.5%    | n:0.5  |
+ * |   ^- 500  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5%  | n:0.5  |
+ * |-----------|------------|------------|----------|--------------|--------|
+ * | Total     | n:102      | n:98       | n:200    |              |        |
+ * `------------------------------------------------------------------------´
+ * ```
+ *
+ * Accessing by category
+ * ---------------------
+ * Use the `sum()`, `average()` and `percentage()` methods to access the values.
+ * In the above example, `sum("OK")['n']` = 195, `average("ERROR")['n']` = 1.5
+ * and `percentage("GOOD")['n']` = 1.0. The subtotals e.g. for client errors can
+ * be accessed by passing in varargs: `sum("ERROR", "client")['n']` = 2.
+ *
+ * To iterate over the categories, use the `rows()` method.
+ *
+ * Accessing by date
+ * -----------------
+ * Pass the date to the `total()` method, e.g. `total("2015-05-10")['n']` = 102.
+ *
+ * To iterate over the dates, use the `columns()` method.
+ *
+ * Grand totals
+ * ------------
+ * Use the `total()` method without any argument to access the grand total for all
+ * values (`['n' => 200]`).
+ *
+ * The `count()` method will return how many columns we spread on (2).
+ *
+ * @test  xp://util.data.unittest.PivotTest
+ */
+class Pivot extends \lang\Object {
+  const TOTAL = 0;
+  const COUNT = 'COUNT';
+  const ROWS  = 2;
+  const COLS  = 3;
+
+  private $groupBy, $spreadOn, $aggregate;
+  private $facts= null;
+
+  /**
+   * Creates a new pivot table
+   * 
+   * @param  (function(var): var)[] $groupBy
+   * @param  function(var): var $spreadOn
+   * @param  [:(function(var): var)] $aggregate
+   * @throws lang.IllegalArgumentException
+   */
+  public function __construct(array $groupBy, \Closure $spreadOn= null, array $aggregate) {
+    if (empty($groupBy)) {
+      throw new IllegalArgumentException('Group by cannot be empty');
+    }
+    $this->groupBy= array_merge($groupBy, [null]);
+    $this->spreadOn= $spreadOn;
+    $this->aggregate= $aggregate;
+  }
+
+  /**
+   * Adds a row to this pivot
+   *
+   * @param  var $row
+   * @return void
+   */
+  public function add($row) {
+    $sums= [];
+    foreach ($this->aggregate as $name => $func) {
+      $sums[$name]= $func($row);
+    }
+    $spread= $this->spreadOn ? $this->spreadOn->__invoke($row) : null;
+
+    $ptr= &$this->facts;
+    foreach ($this->groupBy as $group) {
+      if (isset($ptr)) {
+        foreach ($ptr[self::TOTAL] as $name => $sum) {
+          $ptr[self::TOTAL][$name]+= $sums[$name];
+        }
+        $ptr[self::COUNT]++;
+      } else {
+        $ptr= [self::TOTAL => $sums, self::COUNT => 1, self::ROWS => [], self::COLS => []];
+      }
+
+      if ($this->spreadOn) {
+        $cols= &$ptr[self::COLS];
+        if (isset($cols[$spread])) {
+          foreach ($cols[$spread] as $name => $sum) {
+            $cols[$spread][$name]+= $sums[$name];
+          }
+        } else {
+          $cols[$spread]= $sums;
+        }
+      }
+
+      $group && $ptr= &$ptr[self::ROWS][$group($row)];
+    }
+  }
+
+  /**
+   * Selects a fact
+   *
+   * @param  var[] $paths
+   * @return [:var] An array with ROWS, COLS, and TOTAL
+   */
+  private function fact($paths) {
+    $ptr= &$this->facts;
+    foreach ($paths as $path) {
+      $ptr= &$ptr[self::ROWS][$path];
+    }
+    return $ptr;
+  }
+
+  /**
+   * Returns all rows
+   *
+   * @param  string* $path
+   * @return var[]
+   */
+  public function rows() {
+    return array_keys($this->fact(func_get_args())[self::ROWS]);
+  }
+
+  /**
+   * Returns count
+   *
+   * @param  string* $path
+   * @return int
+   */
+  public function count() {
+    return $this->fact(func_get_args())[self::COUNT];
+  }
+
+  /**
+   * Returns the sum
+   *
+   * @param  string* $path
+   * @return [:var]
+   */
+  public function sum($path) {
+    return $this->fact(func_get_args())[self::TOTAL];
+  }
+
+  /**
+   * Returns the percentage of the grant total
+   *
+   * @param  string* $path
+   * @return [:double]
+   */
+  public function percentage($path) {
+    $fact= $this->fact(func_get_args());
+    $return= [];
+    foreach ($fact[self::TOTAL] as $name => $value) {
+      $return[$name]= $value / $this->facts[self::TOTAL][$name] * 100;
+    }
+    return $return;
+  }
+
+  /**
+   * Returns the average of the values
+   *
+   * @param  string* $path
+   * @return [:double]
+   */
+  public function average($path) {
+    $fact= $this->fact(func_get_args());
+    $return= [];
+    foreach ($fact[self::TOTAL] as $name => $value) {
+      $return[$name]= $value / $fact[self::COUNT];
+    }
+    return $return;
+  }
+
+  /**
+   * Returns all columns
+   *
+   * @return var[]
+   */
+  public function columns() {
+    return array_keys($this->facts[self::COLS]);
+  }
+
+  /**
+   * Returns total
+   *
+   * @param  string $column
+   * @return [:var]
+   */
+  public function total($column= null) {
+    return null === $column ? $this->facts[self::TOTAL] : $this->facts[self::COLS][$column][self::TOTAL];
+  }
+}

--- a/src/main/php/util/data/Pivot.class.php
+++ b/src/main/php/util/data/Pivot.class.php
@@ -49,7 +49,7 @@ use lang\IllegalArgumentException;
  */
 class Pivot extends \lang\Object {
   const TOTAL = 0;
-  const COUNT = 'COUNT';
+  const COUNT = 1;
   const ROWS  = 2;
   const COLS  = 3;
 

--- a/src/main/php/util/data/Pivot.class.php
+++ b/src/main/php/util/data/Pivot.class.php
@@ -23,8 +23,6 @@ use lang\IllegalArgumentException;
  * `-----------------------------------------------------------------------------´
  * ```
  *
- * Accessing a single row can be done via `row()`.
- *
  * Accessing by category
  * ---------------------
  * Use the `sum()`, `average()` and `percentage()` methods to access the values.
@@ -34,12 +32,14 @@ use lang\IllegalArgumentException;
  * of records included in the fact is returned by `count("OK")` = 2.
  *
  * To iterate over the categories, use the `rows()` method.
+ * Accessing a single row can be done via `row()`.
  *
  * Accessing by date
  * -----------------
  * Pass the date to the `total()` method, e.g. `total("2015-05-10")['n']` = 102.
  *
  * To iterate over the dates, use the `columns()` method.
+ * Accessing a single column can be done via `column()`.
  *
  * Grand totals
  * ------------
@@ -92,8 +92,8 @@ class Pivot extends \lang\Object {
     $ptr= &$this->facts;
     foreach ($this->groupBy as $group) {
       if (isset($ptr)) {
-        foreach ($ptr[self::TOTAL] as $name => $sum) {
-          $ptr[self::TOTAL][$name]+= $sums[$name];
+        foreach ($sums as $name => $sum) {
+          $ptr[self::TOTAL][$name]+= $sum;
         }
         $ptr[self::COUNT]++;
       } else {
@@ -101,13 +101,14 @@ class Pivot extends \lang\Object {
       }
 
       if ($this->spreadOn) {
-        $cols= &$ptr[self::COLS];
-        if (isset($cols[$spread])) {
-          foreach ($cols[$spread] as $name => $sum) {
-            $cols[$spread][$name]+= $sums[$name];
+        $cols= &$ptr[self::COLS][$spread];
+        if (isset($cols)) {
+          foreach ($sums as $name => $sum) {
+            $cols[self::TOTAL][$name]+= $sum;
           }
+          $cols[self::COUNT]++;
         } else {
-          $cols[$spread]= $sums;
+          $cols= [self::COUNT => 1, self::TOTAL => $sums];
         }
       }
 
@@ -206,6 +207,16 @@ class Pivot extends \lang\Object {
    */
   public function columns() {
     return array_keys($this->facts[self::COLS]);
+  }
+
+  /**
+   * Returns a single column
+   *
+   * @param  string $column
+   * @return var[]
+   */
+  public function column($column) {
+    return $this->facts[self::COLS][$column];
   }
 
   /**

--- a/src/main/php/util/data/Pivot.class.php
+++ b/src/main/php/util/data/Pivot.class.php
@@ -23,6 +23,8 @@ use lang\IllegalArgumentException;
  * `-----------------------------------------------------------------------------´
  * ```
  *
+ * Accessing a single row can be done via `row()`.
+ *
  * Accessing by category
  * ---------------------
  * Use the `sum()`, `average()` and `percentage()` methods to access the values.
@@ -49,8 +51,8 @@ use lang\IllegalArgumentException;
  * @test  xp://util.data.unittest.PivotTest
  */
 class Pivot extends \lang\Object {
-  const TOTAL = 0;
-  const COUNT = 1;
+  const COUNT = 0;
+  const TOTAL = 1;
   const ROWS  = 2;
   const COLS  = 3;
 
@@ -95,7 +97,7 @@ class Pivot extends \lang\Object {
         }
         $ptr[self::COUNT]++;
       } else {
-        $ptr= [self::TOTAL => $sums, self::COUNT => 1, self::ROWS => [], self::COLS => []];
+        $ptr= [self::COUNT => 1, self::TOTAL => $sums, self::ROWS => [], self::COLS => []];
       }
 
       if ($this->spreadOn) {
@@ -135,6 +137,16 @@ class Pivot extends \lang\Object {
    */
   public function rows() {
     return array_keys($this->fact(func_get_args())[self::ROWS]);
+  }
+
+  /**
+   * Returns a single row
+   *
+   * @param  string* $path
+   * @return var[]
+   */
+  public function row($path) {
+    return $this->fact(func_get_args());
   }
 
   /**

--- a/src/main/php/util/data/PivotCollector.class.php
+++ b/src/main/php/util/data/PivotCollector.class.php
@@ -1,0 +1,75 @@
+<?php namespace util\data;
+
+use util\collections\HashTable;
+
+/**
+ * A collector
+ *
+ * @test  xp://util.data.unittest.PivotTest
+ */
+class PivotCollector extends \lang\Object implements ICollector {
+  private $groupBy= [], $spreadOn= null, $aggregate= [];
+
+  private function select($arg) {
+    if (is_string($arg) || is_int($arg)) {
+      return function($value) use($arg) { return $value[$arg]; };
+    } else {
+      return Functions::$UNARYOP->cast($arg);
+    }
+  }
+
+  /**
+   * Sets what to group by
+   *
+   * @param  var $arg
+   * @return self
+   */
+  public function groupingBy($arg) {
+    $this->groupBy[]= $this->select($arg);
+    return $this;
+  }
+
+  /**
+   * Sets what to spread on
+   *
+   * @param  var $arg
+   * @return self
+   */
+  public function spreadingOn($arg) {
+    $this->spreadOn= $this->select($arg);
+    return $this;
+  }
+
+  /**
+   * Applies sum() aggregate
+   *
+   * @param  var $arg
+   * @param  string $name
+   * @return self
+   */
+  public function summing($arg, $name= null) {
+    if (is_int($arg) || is_string($arg)) {
+      $this->aggregate[null === $name ? $arg : $name]= function($value) use($arg) { return $value[$arg]; };
+    } else {
+      $this->aggregate[$name ?: sizeof($this->aggregate)]= Functions::$UNARYOP->cast($arg);
+    }
+    return $this;
+  }
+
+  /** @return function(): var */
+  public function supplier() {
+    return function() {
+      return new Pivot($this->groupBy, $this->spreadOn, $this->aggregate);
+    };
+  }
+
+  /** @return function(var: var): void */
+  public function accumulator() {
+    return function($pivot, $row) { $pivot->add($row); };
+  }
+
+  /** @return function(var): var */
+  public function finisher() {
+    return null;
+  }
+}

--- a/src/main/php/util/data/PivotCollector.class.php
+++ b/src/main/php/util/data/PivotCollector.class.php
@@ -1,7 +1,5 @@
 <?php namespace util\data;
 
-use util\collections\HashTable;
-
 /**
  * A collector
  *
@@ -10,6 +8,12 @@ use util\collections\HashTable;
 class PivotCollector extends \lang\Object implements ICollector {
   private $groupBy= [], $spreadOn= null, $aggregate= [];
 
+  /**
+   * Helper for groupingBy() and spreadingOn()
+   *
+   * @param  var $arg
+   * @return function(var): var
+   */
   private function select($arg) {
     if (is_string($arg) || is_int($arg)) {
       return function($value) use($arg) { return $value[$arg]; };

--- a/src/test/php/util/data/unittest/PivotTest.class.php
+++ b/src/test/php/util/data/unittest/PivotTest.class.php
@@ -2,6 +2,7 @@
 
 use util\data\Sequence;
 use util\data\Collectors;
+use util\data\Pivot;
 use lang\IllegalArgumentException;
 
 class PivotTest extends AbstractSequenceTest {
@@ -27,6 +28,56 @@ class PivotTest extends AbstractSequenceTest {
   public function rows() {
     $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()->groupingBy('type'));
     $this->assertEquals(['good', 'ok', 'bad'], $pivot->rows());
+  }
+
+  #[@test]
+  public function row() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()->groupingBy('type'));
+    $this->assertEquals(
+      [Pivot::COUNT => 2, Pivot::TOTAL => [], Pivot::ROWS => [], Pivot::COLS => []],
+      $pivot->row('good')
+    );
+  }
+
+  #[@test]
+  public function row_with_sum() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('bytes')
+    );
+    $this->assertEquals(
+      [Pivot::COUNT => 2, Pivot::TOTAL => ['bytes' => 4020], Pivot::ROWS => [], Pivot::COLS => []],
+      $pivot->row('good')
+    );
+  }
+
+  #[@test]
+  public function row_with_sums() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('bytes')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(
+      [Pivot::COUNT => 2, Pivot::TOTAL => ['bytes' => 4020, 'occurrences' => 201], Pivot::ROWS => [], Pivot::COLS => []],
+      $pivot->row('good')
+    );
+  }
+
+  #[@test]
+  public function row_with_spreading() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->spreadingOn('date')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(
+      [Pivot::COUNT => 2, Pivot::TOTAL => ['occurrences' => 201], Pivot::ROWS => [], Pivot::COLS => [
+        '2015-05-10' => ['occurrences' => 100],
+        '2015-05-11' => ['occurrences' => 101]
+      ]],
+      $pivot->row('good')
+    );
   }
 
   #[@test]

--- a/src/test/php/util/data/unittest/PivotTest.class.php
+++ b/src/test/php/util/data/unittest/PivotTest.class.php
@@ -1,0 +1,138 @@
+<?php namespace util\data\unittest;
+
+use util\data\Sequence;
+use util\data\Collectors;
+use lang\IllegalArgumentException;
+
+class PivotTest extends AbstractSequenceTest {
+
+  /** @return var[] */
+  private function measurements() {
+    return [
+      ['type' => 'good', 'status' => 200, 'date' => '2015-05-10', 'bytes' => 2000, 'occurrences' => 100],
+      ['type' => 'good', 'status' => 200, 'date' => '2015-05-11', 'bytes' => 2020, 'occurrences' => 101],
+      ['type' => 'ok',   'status' => 200, 'date' => '2015-05-10', 'bytes' => 200,  'occurrences' => 9],
+      ['type' => 'bad',  'status' => 401, 'date' => '2015-05-10', 'bytes' => 1024, 'occurrences' => 1],
+      ['type' => 'bad',  'status' => 404, 'date' => '2015-05-10', 'bytes' => 1024, 'occurrences' => 4],
+      ['type' => 'bad',  'status' => 500, 'date' => '2015-05-10', 'bytes' => 1280, 'occurrences' => 5],
+    ];
+  }
+
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function groupingBy_cannot_be_omitted() {
+    Sequence::of($this->measurements())->collect(Collectors::toPivot());
+  }
+
+  #[@test]
+  public function rows() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()->groupingBy('type'));
+    $this->assertEquals(['good', 'ok', 'bad'], $pivot->rows());
+  }
+
+  #[@test]
+  public function total() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(220, $pivot->total()['occurrences']);
+  }
+
+  #[@test]
+  public function count() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+    );
+    $this->assertEquals(6, $pivot->count());
+  }
+
+  #[@test, @values([['good', 2], ['ok', 1], ['bad', 3]])]
+  public function count_of($category, $expect) {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+    );
+    $this->assertEquals($expect, $pivot->count($category));
+  }
+
+  #[@test, @values([['good', 201], ['ok', 9], ['bad', 10]])]
+  public function sum_of($category, $expect) {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('occurrences')
+    );
+    $this->assertEquals($expect, $pivot->sum($category)['occurrences']);
+  }
+
+  #[@test, @values([['good', 91.364], ['ok', 4.091], ['bad', 4.545]])]
+  public function percentage_of($category, $expect) {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('occurrences')
+    );
+    $this->assertEquals($expect, round($pivot->percentage($category)['occurrences'], 3));
+  }
+
+  #[@test, @values([['good', 100.500], ['ok', 9.000], ['bad', 3.333]])]
+  public function average_of($category, $expect) {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('occurrences')
+    );
+    $this->assertEquals($expect, round($pivot->average($category)['occurrences'], 3));
+  }
+
+  #[@test]
+  public function columns_empty_when_used_without_spreading() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('occurrences')
+    );
+    $this->assertEquals([], $pivot->columns());
+  }
+
+  #[@test]
+  public function columns() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->spreadingOn('date')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(['2015-05-10', '2015-05-11'], $pivot->columns());
+  }
+
+  #[@test, @values([[401, 1], [404, 4], [500, 5]])]
+  public function grouping_by_multiple_columns($status, $occurrences) {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->groupingBy('status')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(10, $pivot->sum('bad')['occurrences']);
+    $this->assertEquals([401, 404, 500], $pivot->rows('bad'));
+    $this->assertEquals($occurrences, $pivot->sum('bad', $status)['occurrences']);
+    $this->assertEquals($occurrences / 220 * 100, $pivot->percentage('bad', $status)['occurrences']);
+  }
+
+  #[@test]
+  public function summing_multiple_colums() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing('occurrences')
+      ->summing('bytes')
+    );
+    $this->assertEquals(['occurrences' => 10, 'bytes' => 3328], $pivot->sum('bad'));
+  }
+
+  #[@test, @values([
+  #  [null, [10]],
+  #  [0, [10]],
+  #  ['occurrences', ['occurrences' => 10]]
+  #])]
+  public function summing_with_function_and_names($key, $expect) {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->summing(function($row) { return $row['occurrences']; }, $key)
+    );
+    $this->assertEquals($expect, $pivot->sum('bad'));
+  }
+}

--- a/src/test/php/util/data/unittest/PivotTest.class.php
+++ b/src/test/php/util/data/unittest/PivotTest.class.php
@@ -73,8 +73,8 @@ class PivotTest extends AbstractSequenceTest {
     );
     $this->assertEquals(
       [Pivot::COUNT => 2, Pivot::TOTAL => ['occurrences' => 201], Pivot::ROWS => [], Pivot::COLS => [
-        '2015-05-10' => ['occurrences' => 100],
-        '2015-05-11' => ['occurrences' => 101]
+        '2015-05-10' => [Pivot::COUNT => 1, Pivot::TOTAL => ['occurrences' => 100]],
+        '2015-05-11' => [Pivot::COUNT => 1, Pivot::TOTAL => ['occurrences' => 101]]
       ]],
       $pivot->row('good')
     );
@@ -87,6 +87,16 @@ class PivotTest extends AbstractSequenceTest {
       ->summing('occurrences')
     );
     $this->assertEquals(220, $pivot->total()['occurrences']);
+  }
+
+  #[@test]
+  public function total_by_date() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->spreadingOn('date')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(119, $pivot->total('2015-05-10')['occurrences']);
   }
 
   #[@test]
@@ -149,6 +159,19 @@ class PivotTest extends AbstractSequenceTest {
       ->summing('occurrences')
     );
     $this->assertEquals(['2015-05-10', '2015-05-11'], $pivot->columns());
+  }
+
+  #[@test]
+  public function column() {
+    $pivot= Sequence::of($this->measurements())->collect(Collectors::toPivot()
+      ->groupingBy('type')
+      ->spreadingOn('date')
+      ->summing('occurrences')
+    );
+    $this->assertEquals(
+      [Pivot::COUNT => 5, Pivot::TOTAL => ['occurrences' => 119]],
+      $pivot->column('2015-05-10')
+    );
   }
 
   #[@test, @values([[401, 1], [404, 4], [500, 5]])]


### PR DESCRIPTION
Pivot
=====
```
.-----------------------------------------------------------------------------.
| Category  | 2015-05-10 | 2015-05-11 | Sum      | Percentage | Count | Avg.   |
|-----------|------------|------------|----------|------------|-------|--------|
| OK        | n:100      | n:95       | n:195    | n:97.5     | n:2   | n:97.5 |
| GOOD      | n:2        | n:0        | n:2      | n:1.0      | n:1   | n:2    |
| ERROR     | n:0        | n:3        | n:3      | n:1.5      | n:3   | n:1.0  |
| ^- client | ^- n:0     | ^- n:2     | ^- n:2   | ^- n:1.0   | n:3   | n:0.67 |
|   ^- 403  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5 | n:1   | n:1.0  |
|   ^- 404  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5 | n:2   | n:0.5  |
| ^- server | ^- n:0     | ^- n:1     | ^- n:1   | ^- n:0.5   | n:1   | n:0.5  |
|   ^- 500  |   ^- n:0   |   ^- n:1   |   ^- n:1 |   ^- n:0.5 | n:1   | n:0.5  |
|-----------|------------|------------|----------|------------|-------|--------|
| Total     | n:102      | n:98       | n:200    |            | n:14  |        |
`-----------------------------------------------------------------------------´
```
Accessing by category
---------------------
Use the `sum()`, `average()` and `percentage()` methods to access the values. In the above example, `sum("OK")['n']` = 195, `average("ERROR")['n']` = 1.5 and `percentage("GOOD")['n']` = 1.0. The subtotals e.g. for client errors can be accessed by passing in varargs: `sum("ERROR", "client")['n']` = 2. The number of records included in the fact is returned by `count("OK")` = 2.

To iterate over the categories, use the `rows()` method.
Accessing a single row can be done via `row()`.

Accessing by date
-----------------
Pass the date to the `total()` method, e.g. `total("2015-05-10")['n']` = 102.

To iterate over the dates, use the `columns()` method.
Accessing a single column can be done via `column()`.

Grand totals
------------
Use the `total()` method without any argument to access the grand total for all
values (`['n' => 200]`).

The `count()` method will return many records we processed on (14).