### PR TITLE
Optional features

### DIFF
--- a/src/main/php/util/data/Optional.class.php
+++ b/src/main/php/util/data/Optional.class.php
@@ -62,13 +62,23 @@ class Optional extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
-   * Gets this optional's value, or a given default value, if no value is present.
+   * Gets this optional's value, or a given default value if no value is present.
    *
    * @param  var $default
    * @return var
    */
   public function orElse($default) {
     return $this->present ? $this->value : $default;
+  }
+
+  /**
+   * Gets this optional's value, or invoke a given supplier if no value is present.
+   *
+   * @param  function(): var $supplier
+   * @return var
+   */
+  public function orUse($supplier) {
+    return $this->present ? $this->value : Functions::$SUPPLY->newInstance($supplier)->__invoke();
   }
 
   /**
@@ -102,7 +112,6 @@ class Optional extends \lang\Object implements \IteratorAggregate {
   public function map($function) {
     if (!$this->present) return self::$EMPTY;
 
-    $mapper= Functions::$APPLY->newInstance($function);
-    return self::of($mapper($this->value));
+    return self::of(Functions::$APPLY->newInstance($function)->__invoke($this->value));
   }
 }

--- a/src/main/php/util/data/Optional.class.php
+++ b/src/main/php/util/data/Optional.class.php
@@ -1,6 +1,7 @@
 <?php namespace util\data;
 
 use util\NoSuchElementException;
+use util\Filter;
 
 /**
  * An optional
@@ -68,5 +69,40 @@ class Optional extends \lang\Object implements \IteratorAggregate {
    */
   public function orElse($default) {
     return $this->present ? $this->value : $default;
+  }
+
+  /**
+   * Returns a new optional by applying the given mapper to this optional's value.
+   * If this optional is empty, returns itself.
+   *
+   * @param  var $predicate either a util.Filter instance or a function
+   * @return self
+   * @throws lang.IllegalArgumentException
+   */
+  public function filter($predicate) {
+    if (!$this->present) return self::$EMPTY;
+
+    if ($predicate instanceof Filter || is('util.Filter<?>', $predicate)) {
+      $filter= Functions::$APPLY->cast([$predicate, 'accept']);
+    } else {
+      $filter= Functions::$APPLY->newInstance($predicate);
+    }
+
+    return $filter($this->value) ? $this : self::$EMPTY;
+  }
+
+  /**
+   * Returns a new optional by applying the given mapper to this optional's value.
+   * If this optional is empty, returns itself.
+   *
+   * @param  function(var): var $function
+   * @return self
+   * @throws lang.IllegalArgumentException
+   */
+  public function map($function) {
+    if (!$this->present) return self::$EMPTY;
+
+    $mapper= Functions::$APPLY->newInstance($function);
+    return self::of($mapper($this->value));
   }
 }

--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use lang\types\String;
+use lang\Object;
 use lang\types\ArrayList;
 use util\data\Sequence;
 use util\data\Collector;
@@ -72,7 +72,7 @@ abstract class AbstractSequenceTest extends \unittest\TestCase {
   protected function noncallables() {
     return [
       [null], [''], ['...'], [-1], [0], [1], [0.5], [false], [true],
-      [new \lang\Object()], [new String('...')], [$this],
+      [new Object()], [new Name('...')], [$this],
       [[]], [[$this]], [['xp']], [['xp', 'g']], [[$this, 'getName', 'excess-element']],
       ['xp:g'], ['xp::'], ['xp::g'], ['::gc'], ['typeo']
     ];

--- a/src/test/php/util/data/unittest/Enumerables.class.php
+++ b/src/test/php/util/data/unittest/Enumerables.class.php
@@ -2,7 +2,6 @@
 
 use lang\types\ArrayList;
 use lang\types\ArrayMap;
-use lang\types\String;
 use lang\Object;
 use util\data\Sequence;
 
@@ -126,7 +125,7 @@ abstract class Enumerables extends Object {
   public static function invalid() {
     return [
       [''], ['...'], [-1], [0], [1], [0.5], [false], [true],
-      [new Object()], [new String('...')],
+      [new Object()], [new Name('...')],
       [function() { return 1; }]
     ];
   }

--- a/src/test/php/util/data/unittest/Name.class.php
+++ b/src/test/php/util/data/unittest/Name.class.php
@@ -1,0 +1,39 @@
+<?php namespace util\data\unittest;
+
+class Name extends \lang\Object {
+  private $value;
+
+  /** @param string $value */
+  public function __construct($value) { $this->value= $value; }
+
+  /** @return string */
+  public function value() { return $this->value; }
+
+  /**
+   * Returns a hashcode
+   *
+   * @return string
+   */
+  public function hashCode() {
+    return crc32($this->value);
+  }
+
+  /**
+   * Returns whether this name is equal to another
+   *
+   * @param  var $cmp
+   * @return bool
+   */
+  public function equals($cmp) {
+    return $cmp instanceof self && $this->value === $cmp->value;
+  }
+
+  /**
+   * Returns a string representation
+   *
+   * @return string
+   */
+  public function toString() {
+    return $this->getClassName().'('.$this->value.')';
+  }
+}

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -43,4 +43,29 @@ class OptionalTest extends \unittest\TestCase {
   public function empty_can_be_used_in_foreach() {
     $this->assertEquals([], iterator_to_array(Optional::$EMPTY));
   }
+
+  #[@test]
+  public function filter_returns_empty_when_no_value_present() {
+    $this->assertEquals(Optional::$EMPTY, Optional::$EMPTY->filter('is_array'));
+  }
+
+  #[@test]
+  public function filter_returns_self_when_predicate_matches() {
+    $this->assertEquals([1, 2, 3], Optional::of([1, 2, 3])->filter('is_array')->get());
+  }
+
+  #[@test]
+  public function filter_returns_empty_when_predicate_does_not_match() {
+    $this->assertEquals(Optional::$EMPTY, Optional::of('test')->filter('is_array'));
+  }
+
+  #[@test]
+  public function map_applies_function_when_value_present() {
+    $this->assertEquals('123', Optional::of([1, 2, 3])->map('implode')->get());
+  }
+
+  #[@test]
+  public function map_returns_empty_when_no_value_present() {
+    $this->assertEquals(Optional::$EMPTY, Optional::$EMPTY->map('implode'));
+  }
 }

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace util\data\unittest;
 
 use util\data\Optional;
+use lang\IllegalStateException;
 
 class OptionalTest extends \unittest\TestCase {
 
@@ -32,6 +33,18 @@ class OptionalTest extends \unittest\TestCase {
   #[@test]
   public function orElse_returns_default_when_no_value_is_present() {
     $this->assertEquals('Succeeded', Optional::$EMPTY->orElse('Succeeded'));
+  }
+
+  #[@test]
+  public function orUse_returns_value_passed_to_of() {
+    $this->assertEquals('Test', Optional::of('Test')->orUse(function() {
+      throw new IllegalStateException('No reached');
+    }));
+  }
+
+  #[@test]
+  public function orUse_invokes_supplier_when_no_value_is_present() {
+    $this->assertEquals('Succeeded', Optional::$EMPTY->orUse(function() { return 'Succeeded'; }));
   }
 
   #[@test]

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -1,6 +1,5 @@
 <?php namespace util\data\unittest;
 
-use lang\types\String;
 use util\cmd\Console;
 use util\data\Sequence;
 use util\data\Optional;
@@ -78,7 +77,7 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test, @values([
   #  [[1, 2, 3], [1, 2, 2, 3, 1, 3]],
-  #  [[new String('a'), new String('b')], [new String('a'), new String('a'), new String('b')]]
+  #  [[new Name('a'), new Name('b')], [new Name('a'), new Name('a'), new Name('b')]]
   #])]
   public function distinct($result, $input) {
     $this->assertSequence($result, Sequence::of($input)->distinct());


### PR DESCRIPTION
This pull request adds `filter()`, `map()` and `orUse()` implementations to util.data.Optional:

* **filter**: Returns the value if a value is present and the given predicate matches it, empty otherwise
* **map**: Applies a function on the value and returns its result if a value is present, empty otherwise
* **orUse**: Variation of `orElse()` which takes a function instead of a value, deferring its invocation to when no value is present. Use when the value passed to it requires lengthy calculation

### Example

```php
use webservices\rest\srv\Response;

#[@webservice(path= '/users')]
class UserResource extends \lang\Object {

  // ...shortened for brevity...

  #[@webmethod(verb= 'GET', path= '/{id}')]
  public function get($id) {
    return $this->users->findById($id)
      ->filter(function($user) { return !$user->isDeleted(); })
      ->map(function($user) { return Response::ok()->withPayload($user); })
      ->orUse(function() use($id) {
        return Response::notFound()->withPayload('Cannot find user #'.$id));
      })
    ;
  }
}
```

@gelli Thanks for inspiring me [with this](https://github.com/gelli/tritos/blob/master/src/main/java/info/mindblast/tritos/web/rest/UserResource.java)!