### PR TITLE
Rename whenNull() to whenAbsent()

### DIFF
--- a/src/main/php/util/data/Optional.class.php
+++ b/src/main/php/util/data/Optional.class.php
@@ -86,13 +86,13 @@ class Optional extends \lang\Object implements \IteratorAggregate {
    * @param  var $default
    * @return self
    */
-  public function whenNull($default) {
+  public function whenAbsent($default) {
     if ($this->present) {
       return $this;
     } else if ($default instanceof self) {
       return $default;
     } else if ($default instanceof \Closure) {
-      return $this->whenNull($default());
+      return $this->whenAbsent($default());
     } else {
       return self::of($default);
     }

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -53,23 +53,23 @@ class OptionalTest extends \unittest\TestCase {
   }
 
   #[@test]
-  public function whenNull_returns_value_passed_to_of() {
-    $this->assertEquals('Test', Optional::of('Test')->whenNull('Failed')->get());
+  public function whenAbsent_returns_value_passed_to_of() {
+    $this->assertEquals('Test', Optional::of('Test')->whenAbsent('Failed')->get());
   }
 
   #[@test]
-  public function whenNull_returns_value_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenNull('Succeeded')->get());
+  public function whenAbsent_returns_value_when_no_value_is_present() {
+    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent('Succeeded')->get());
   }
 
   #[@test]
-  public function whenNull_returns_optionals_value_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenNull(Optional::of('Succeeded'))->get());
+  public function whenAbsent_returns_optionals_value_when_no_value_is_present() {
+    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent(Optional::of('Succeeded'))->get());
   }
 
   #[@test]
-  public function whenNull_returns_functions_return_value_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenNull(function() { return 'Succeeded'; })->get());
+  public function whenAbsent_returns_functions_return_value_when_no_value_is_present() {
+    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent(function() { return 'Succeeded'; })->get());
   }
 
   #[@test, @values([
@@ -78,8 +78,8 @@ class OptionalTest extends \unittest\TestCase {
   #  [function() { return null; }],
   #  [function() { return \util\data\Optional::$EMPTY; }]
   #])]
-  public function whenNull_chaining($value) {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenNull($value)->whenNull('Succeeded')->get());
+  public function whenAbsent_chaining($value) {
+    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent($value)->whenAbsent('Succeeded')->get());
   }
 
   #[@test]


### PR DESCRIPTION
Better matches present() method, which isn't called isNull()

Thanks @bitionaire!