### PR TITLE
Implement support for mapping keys

### DIFF
--- a/src/main/php/util/data/AbstractMapper.class.php
+++ b/src/main/php/util/data/AbstractMapper.class.php
@@ -5,8 +5,8 @@
  * iterator returns and returns its result.
  */
 abstract class AbstractMapper extends \lang\Object implements \Iterator {
-  protected $it;
-  protected $func;
+  protected $it, $func;
+  private $current, $key, $valid;
 
   /**
    * Creates a new Mapper instance
@@ -19,18 +19,40 @@ abstract class AbstractMapper extends \lang\Object implements \Iterator {
     $this->func= $func;
   }
 
-  /** @return void */
-  public function rewind() { $this->it->rewind(); }
-
   /** @return var */
-  public abstract function current();
-
-  /** @return var */
-  public function key() { return $this->it->key(); }
+  protected abstract function map();
 
   /** @return void */
-  public function next() { $this->it->next(); }
+  protected function forward() {
+    if ($this->valid= $this->it->valid()) {
+      $result= $this->map();
+      if ($result instanceof \Generator) {
+        foreach ($result as $this->key => $this->current) { }
+      } else {
+        $this->key= $this->it->key();
+        $this->current= $result;
+      }
+    }
+  }
+
+  /** @return void */
+  public function rewind() {
+    $this->it->rewind();
+    $this->forward();
+  }
+
+  /** @return void */
+  public function next() {
+    $this->it->next();
+    $this->forward();
+  }
+
+  /** @return var */
+  public function current() { return $this->current; }
+
+  /** @return var */
+  public function key() { return $this->key; }
 
   /** @return bool */
-  public function valid() { return $this->it->valid(); }
+  public function valid() { return $this->valid; }
 }

--- a/src/main/php/util/data/Mapper.class.php
+++ b/src/main/php/util/data/Mapper.class.php
@@ -9,7 +9,7 @@
 class Mapper extends AbstractMapper {
 
   /** @return var */
-  public function current() {
+  public function map() {
     return $this->func->__invoke($this->it->current());
   }
 }

--- a/src/main/php/util/data/MapperWithKey.class.php
+++ b/src/main/php/util/data/MapperWithKey.class.php
@@ -7,7 +7,7 @@
 class MapperWithKey extends AbstractMapper {
 
   /** @return var */
-  public function current() {
+  public function map() {
     return $this->func->__invoke($this->it->current(), $this->it->key());
   }
 }

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -10,13 +10,6 @@ class SequenceMappingTest extends AbstractSequenceTest {
     $this->assertSequence([2, 4, 6, 8], Sequence::of([1, 2, 3, 4])->map(function($e) { return $e * 2; }));
   }
 
-  #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
-  public function with_generator() {
-    $records= Sequence::of([['unit' => 'yellow', 'amount' => 20], ['unit' => 'blue', 'amount' => 19]]);
-    $generator= eval('return function($record) { yield $record["unit"] => $record["amount"]; };');
-    $this->assertEquals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
-  }
-
   #[@test]
   public function with_with_floor_native_function() {
     $this->assertSequence([1.0, 2.0, 3.0], Sequence::of([1.9, 2.5, 3.1])->map('floor'));
@@ -48,5 +41,20 @@ class SequenceMappingTest extends AbstractSequenceTest {
       ['Timm', 'Test'],
       Sequence::of($people)->map('util.data.unittest.Person::name')
     );
+  }
+
+  #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
+  public function with_generator() {
+    $records= Sequence::of([['unit' => 'yellow', 'amount' => 20], ['unit' => 'blue', 'amount' => 19]]);
+    $generator= eval('return function($record) { yield $record["unit"] => $record["amount"]; };');
+    $this->assertEquals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
+  }
+
+
+  #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
+  public function with_generator_and_key() {
+    $records= Sequence::of(['color' => 'green', 'price' => 12.99]);
+    $generator= eval('return function($value, $key) { yield strtoupper($key) => $value; };');
+    $this->assertEquals(['COLOR' => 'green', 'PRICE' => 12.99], $records->map($generator)->toMap());
   }
 }

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -50,7 +50,6 @@ class SequenceMappingTest extends AbstractSequenceTest {
     $this->assertEquals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
   }
 
-
   #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
   public function with_generator_and_key() {
     $records= Sequence::of(['color' => 'green', 'price' => 12.99]);

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -1,12 +1,20 @@
 <?php namespace util\data\unittest;
 
 use util\data\Sequence;
+use unittest\actions\VerifyThat;
 
 class SequenceMappingTest extends AbstractSequenceTest {
 
   #[@test]
   public function with_function() {
     $this->assertSequence([2, 4, 6, 8], Sequence::of([1, 2, 3, 4])->map(function($e) { return $e * 2; }));
+  }
+
+  #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
+  public function with_generator() {
+    $records= Sequence::of([['unit' => 'yellow', 'amount' => 20], ['unit' => 'blue', 'amount' => 19]]);
+    $generator= eval('return function($record) { yield $record["unit"] => $record["amount"]; };');
+    $this->assertEquals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
   }
 
   #[@test]


### PR DESCRIPTION
This pull request adds support for returning keys from a mapper function by using PHP 5.5's / HHVM's `yield` statement.

### Examples

```php
$records= Sequence::of([['unit' => 'yellow', 'count' => 20], ['unit' => 'blue', 'count' => 19]]);
$this->assertEquals(
  ['yellow' => 20, 'blue' => 19],
  $records->map(function($record) { yield $record['unit'] => $record['count']; )->toMap()
);

$entry= Sequence::of(['color' => 'green', 'price' => 12.99]);
$this->assertEquals(
  ['COLOR' => 'green', 'PRICE' => 12.99],
  $entry->map(function($value, $key) { yield strtoupper($key) => $value; })->toMap()
);
```

This differs from writing a collector in that `map()`'s result is still a stream, while collecting is a terminal operation.

See http://stackoverflow.com/questions/9130368/map-both-keys-and-values-of-a-scala-map