### PR TITLE
Implement support for using keys in collect()

### DIFF
--- a/src/main/php/util/data/Collector.class.php
+++ b/src/main/php/util/data/Collector.class.php
@@ -15,12 +15,16 @@ class Collector extends \lang\Object implements ICollector {
    * Create a new instance
    *
    * @param  function(): var $supplier
-   * @param  function(var, var): var $accumulator
+   * @param  (function(var, var): var|function(var, var, var): var) $accumulator
    * @param  function(var): var $finisher
    */
   public function __construct($supplier, $accumulator, $finisher= null) {
     $this->supplier= Functions::$SUPPLY->newInstance($supplier);
-    $this->accumulator= Functions::$CONSUME->newInstance($accumulator);
+    if (Functions::$CONSUME_WITH_KEY->isInstance($accumulator)) {
+      $this->accumulator= Functions::$CONSUME_WITH_KEY->cast($accumulator);
+    } else {
+      $this->accumulator= Functions::$CONSUME->newInstance($accumulator);
+    }
     $this->finisher= null === $finisher ? null : Functions::$APPLY->newInstance($finisher);
   }
 

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -57,8 +57,18 @@ final class Collectors extends \lang\Object {
    * @param  function(var): var $value If omitted, element is used in value
    * @return util.data.ICollector
    */
-  public static function toMap($key, $value= null) {
-    if (null === $value) {
+  public static function toMap($key= null, $value= null) {
+    if (null === $key && null === $value) {
+      return new Collector(
+        function() { return new HashTable(); },
+        function($result, $arg, $key) { $result->put($key, $arg); }
+      );
+    } else if (null === $key) {
+      return new Collector(
+        function() { return new HashTable(); },
+        function($result, $arg, $key) use($value) { $result->put($key, $value($arg)); }
+      );
+    } else if (null === $value) {
       return new Collector(
         function() { return new HashTable(); },
         function($result, $arg) use($key) { $result->put($key($arg), $arg); }

--- a/src/main/php/util/data/Functions.class.php
+++ b/src/main/php/util/data/Functions.class.php
@@ -8,11 +8,12 @@ use lang\Primitive;
  * Function types used throughout library
  */
 abstract class Functions extends \lang\Object {
-  public static $SUPPLY, $CONSUME, $UNARYOP, $BINARYOP, $COMPARATOR, $APPLY, $APPLY_WITH_KEY;
+  public static $SUPPLY, $CONSUME, $CONSUME_WITH_KEY, $UNARYOP, $BINARYOP, $COMPARATOR, $APPLY, $APPLY_WITH_KEY;
 
   static function __static() {
     self::$SUPPLY= new FunctionType([], Type::$VAR);
     self::$CONSUME= new FunctionType([Type::$VAR, Type::$VAR], Type::$VOID);
+    self::$CONSUME_WITH_KEY= new FunctionType([Type::$VAR, Type::$VAR, Type::$VAR], Type::$VOID);
     self::$UNARYOP= new FunctionType([Type::$VAR], Type::$VAR);
     self::$BINARYOP= new FunctionType([Type::$VAR, Type::$VAR], Type::$VAR);
     self::$COMPARATOR= new FunctionType([Type::$VAR, Type::$VAR], Primitive::$INT);

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -294,10 +294,15 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
       $finisher= $collector->finisher();
 
       $return= $collector->supplier()->__invoke();
-      foreach ($this->elements as $element) {
-        $accumulator($return, $element);
+      if (Functions::$CONSUME_WITH_KEY->isInstance($accumulator)) {
+        foreach ($this->elements as $key => $element) {
+          $accumulator($return, $element, $key);
+        }
+      } else {
+        foreach ($this->elements as $element) {
+          $accumulator($return, $element);
+        }
       }
-
       return $finisher ? $finisher($return) : $return;
     });
   }

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -284,7 +284,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Performs a mutable reduction operation on the elements of this stream.
    *
-   * @param  util.data.ICollector
+   * @param  util.data.ICollector $collector
    * @return var
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -93,6 +93,25 @@ class CollectorsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function toMap_can_use_sequence_keys() {
+    $map= new HashTable();
+    $map['color']= 'green';
+
+    $this->assertEquals($map, Sequence::of(['color' => 'green'])->collect(Collectors::toMap()));
+  }
+
+  #[@test]
+  public function toMap_key_function_can_be_omitted() {
+    $map= new HashTable();
+    $map['color']= 'GREEN';
+
+    $this->assertEquals($map, Sequence::of(['color' => 'green'])->collect(Collectors::toMap(
+      null,
+      'strtoupper'
+    )));
+  }
+
+  #[@test]
   public function summing_years() {
     $this->assertEquals(33, Sequence::of($this->people)
       ->collect(Collectors::summing(function($e) { return $e->years(); }))

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -2,6 +2,7 @@
 
 use util\data\Sequence;
 use util\data\Collectors;
+use util\data\Collector;
 use util\collections\Vector;
 use util\collections\HashSet;
 use util\collections\HashTable;
@@ -109,6 +110,15 @@ class CollectorsTest extends \unittest\TestCase {
       null,
       'strtoupper'
     )));
+  }
+
+  #[@test]
+  public function collect_with_key() {
+    $result= Sequence::of(['color' => 'green', 'price' => 12.99])->collect(new Collector(
+      function() { return []; },
+      function(&$result, $arg, $key) { $result[strtoupper($key)]= $arg; }
+    ));
+    $this->assertEquals(['COLOR' => 'green', 'PRICE' => 12.99], $result);
   }
 
   #[@test]


### PR DESCRIPTION
This pull request adds the ability to access keys inside a collector's accumulator function.

### Example

```php
$result= Sequence::of(['color' => 'green', 'price' => 12.99])->collect(new Collector(
  function() { return []; },
  function(&$result, $arg, $key) { $result[strtoupper($key)]= $arg; }
));

// ['COLOR' => 'green', 'PRICE' => 12.99];
```