### PR TITLE
Enter PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Data sequences
 [![Build Status on TravisCI](https://secure.travis-ci.org/xp-forge/sequence.svg)](http://travis-ci.org/xp-forge/sequence)
 [![XP Framework Module](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
-[![Required PHP 5.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_4plus.png)](http://php.net/)
+[![Required PHP 5.5+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-5_5plus.png)](http://php.net/)
 [![Supports PHP 7.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-7_0plus.png)](http://php.net/)
 [![Supports HHVM 3.4+](https://raw.githubusercontent.com/xp-framework/web/master/static/hhvm-3_4plus.png)](http://hhvm.com/)
 [![Latest Stable Version](https://poser.pugx.org/xp-forge/sequence/version.png)](https://packagist.org/packages/xp-forge/sequence)

--- a/src/test/php/util/data/unittest/BoundariesTest.class.php
+++ b/src/test/php/util/data/unittest/BoundariesTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data\unittest;
 
+use util\Comparator;
 use util\data\Sequence;
 use util\Date;
 
@@ -18,7 +19,7 @@ class BoundariesTest extends AbstractSequenceTest {
   public function min_using_comparator() {
     $this->assertEquals(
       new Date('1977-12-14'),
-      Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->min(newinstance('util.Comparator', [], [
+      Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->min(newinstance(Comparator::class, [], [
         'compare' => function($a, $b) { return $b->compareTo($a); }
       ]))
     );
@@ -47,7 +48,7 @@ class BoundariesTest extends AbstractSequenceTest {
   public function max_using_comparator() {
     $this->assertEquals(
       new Date('2014-07-17'),
-      Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->max(newinstance('util.Comparator', [], [
+      Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->max(newinstance(Comparator::class, [], [
         'compare' => function($a, $b) { return $b->compareTo($a); }
       ]))
     );

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -30,7 +30,7 @@ class CollectorsTest extends \unittest\TestCase {
    * @throws unittest.AssertionFailedError
    */
   protected function assertHashTable($expected, $actual) {
-    $this->assertInstanceOf('util.collections.HashTable', $actual);
+    $this->assertInstanceOf(HashTable::class, $actual);
     $compare= [];
     foreach ($actual as $pair) {
       $compare[$pair->key]= $pair->value;

--- a/src/test/php/util/data/unittest/Enumerables.class.php
+++ b/src/test/php/util/data/unittest/Enumerables.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data\unittest;
 
+use util\XPIterator;
 use lang\types\ArrayList;
 use lang\types\ArrayMap;
 use lang\Object;
@@ -77,12 +78,12 @@ abstract class Enumerables extends Object {
         [eval('$f= function() { yield 1; yield 2; yield 3; }; return $f();'), 'generator']
       ] : [],
       [
-        [newinstance('util.XPIterator', [], '{
+        [newinstance(XPIterator::class, [], '{
           protected $numbers= [1, 2, 3];
           public function hasNext() { return !empty($this->numbers); }
           public function next() { return array_shift($this->numbers); }
         }'), 'xp-iterator'],
-        [Sequence::of(newinstance('util.XPIterator', [], '{
+        [Sequence::of(newinstance(XPIterator::class, [], '{
           protected $numbers= [1, 2, 3];
           public function hasNext() { return !empty($this->numbers); }
           public function next() { return array_shift($this->numbers); }

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -12,7 +12,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test, @values('util.data.unittest.Enumerables::valid')]
   public function can_create_via_of($input, $name) {
-    $this->assertInstanceOf('util.data.Sequence', Sequence::of($input), $name);
+    $this->assertInstanceOf(Sequence::class, Sequence::of($input), $name);
   }
 
   #[@test, @expect('lang.IllegalArgumentException'), @values('util.data.unittest.Enumerables::invalid')]
@@ -22,7 +22,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test, @values('unaryops')]
   public function can_create_via_iterate($input, $name) {
-    $this->assertInstanceOf('util.data.Sequence', Sequence::iterate(0, $input), $name);
+    $this->assertInstanceOf(Sequence::class, Sequence::iterate(0, $input), $name);
   }
 
   #[@test, @expect('lang.IllegalArgumentException'), @values('noncallables')]
@@ -32,7 +32,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test, @values('suppliers')]
   public function can_create_via_generate($input) {
-    $this->assertInstanceOf('util.data.Sequence', Sequence::generate($input));
+    $this->assertInstanceOf(Sequence::class, Sequence::generate($input));
   }
 
   #[@test, @expect('lang.IllegalArgumentException'), @values('noncallables')]

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data\unittest;
 
+use util\Filter;
 use util\data\Sequence;
 
 class SequenceFilteringTest extends AbstractSequenceTest {
@@ -16,7 +17,7 @@ class SequenceFilteringTest extends AbstractSequenceTest {
 
   #[@test]
   public function with_filter_instance() {
-    $this->assertSequence(['Hello', 'World'], Sequence::of(['Hello', '', 'World'])->filter(newinstance('util.Filter', [], [
+    $this->assertSequence(['Hello', 'World'], Sequence::of(['Hello', '', 'World'])->filter(newinstance(Filter::class, [], [
       'accept' => function($e) { return strlen($e) > 0; }
     ])));
   }

--- a/src/test/php/util/data/unittest/SequenceSortingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSortingTest.class.php
@@ -24,7 +24,7 @@ class SequenceSortingTest extends AbstractSequenceTest {
   public function sorted_by_comparator() {
     $this->assertSequence(
       [new Date('1977-12-14'), new Date('1979-12-29')],
-      Sequence::of([new Date('1979-12-29'), new Date('1977-12-14')])->sorted(newinstance('util.Comparator', [], [
+      Sequence::of([new Date('1979-12-29'), new Date('1977-12-14')])->sorted(newinstance(Comparator::class, [], [
         'compare' => function($a, $b) { return $b->compareTo($a); }
       ]))
     );


### PR DESCRIPTION
This pull request drops PHP 5.4 support by starting to rely on `T::class` and bumps the minimum PHP version required to 5.5.

*Note: As the main source is not touched, unofficial PHP 5.4 support is still available though not tested with Travis-CI. In a future release, we could start rewriting the entire code base to use yield statements! This is consistent with [xp core 6.5.0](https://github.com/xp-framework/core/releases/tag/v6.5.0).*