### PR TITLE
Add support for optional mapper in toSet() and toList()

### DIFF
--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -16,24 +16,26 @@ final class Collectors extends \lang\Object {
   /**
    * Creates a new collector gathering the elements in a list
    *
+   * @param  function(var): var $value If omitted, element is used in value
    * @return util.data.ICollector
    */
-  public static function toList() {
-    return new Collector(
-      function() { return new Vector(); },
-      function($result, $arg) { $result->add($arg); }
+  public static function toList($value= null) {
+    return new Collector(function() { return new Vector(); }, null === $value
+      ? function($result, $arg) { $result->add($arg); }
+      : function($result, $arg) use($value) { $result->add($value($arg)); }
     );
   }
 
   /**
-   * Creates a new collector gathering the elements in a list
+   * Creates a new collector gathering the elements in a set
    *
+   * @param  function(var): var $value If omitted, element is used in value
    * @return util.data.ICollector
    */
-  public static function toSet() {
-    return new Collector(
-      function() { return new HashSet(); },
-      function($result, $arg) { $result->add($arg); }
+  public static function toSet($value= null) {
+    return new Collector(function() { return new HashSet(); }, null === $value
+      ? function($result, $arg) { $result->add($arg); }
+      : function($result, $arg) use($value) { $result->add($value($arg)); }
     );
   }
 

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -40,9 +40,10 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test]
   public function toList() {
-    $this->assertEquals(new Vector(['Timm', 'Alex', 'Dude']), Sequence::of($this->people)
+    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::toList())
+      ->elements()
     );
   }
 
@@ -56,12 +57,10 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test]
   public function toSet() {
-    $set= new HashSet();
-    $set->addAll(['Timm', 'Alex', 'Dude']);
-
-    $this->assertEquals($set, Sequence::of($this->people)
+    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::toSet())
+      ->toArray()
     );
   }
 
@@ -75,12 +74,10 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test]
   public function toCollection_with_HashSet_class() {
-    $set= new HashSet();
-    $set->addAll(['Timm', 'Alex', 'Dude']);
-
-    $this->assertEquals($set, Sequence::of($this->people)
+    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::toCollection(XPClass::forName('util.collections.HashSet')))
+      ->toArray()
     );
   }
 

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -47,6 +47,14 @@ class CollectorsTest extends \unittest\TestCase {
   }
 
   #[@test]
+  public function toList_with_extraction() {
+    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+      ->collect(Collectors::toList(function($e) { return $e->name(); }))
+      ->elements()
+    );
+  }
+
+  #[@test]
   public function toSet() {
     $set= new HashSet();
     $set->addAll(['Timm', 'Alex', 'Dude']);
@@ -54,6 +62,14 @@ class CollectorsTest extends \unittest\TestCase {
     $this->assertEquals($set, Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::toSet())
+    );
+  }
+
+  #[@test]
+  public function toSet_with_extraction() {
+    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+      ->collect(Collectors::toSet(function($e) { return $e->name(); }))
+      ->toArray()
     );
   }
 


### PR DESCRIPTION
This makes these two methods consistent with toMap(). This comes in handy when using `Collectors::toX()` in conjunction with grouping:

```php
$namesByDepartment= Sequence::of($this->employees)
  ->collect(Collectors::groupingBy(
    function($e) { return $e->department()->name(); },
    Collectors::toList(function($e) { return $e->name(); })
  ))
;

// = [
//  'System Administration' => ['Jon', 'Paul'],
//  'Infrastructure Development' => ['Ben', 'The Dude']
// ]