### PR TITLE
Fix Collectors class' methods to cast given functions

### DIFF
--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -159,6 +159,7 @@ final class Collectors extends \lang\Object {
    */
   public static function partitioningBy($predicate, ICollector $collector= null) {
     if (null === $collector) $collector= self::toList();
+    $func= Functions::$APPLY->cast($predicate);
     $supplier= $collector->supplier();
     $accumulator= $collector->accumulator();
 
@@ -169,8 +170,8 @@ final class Collectors extends \lang\Object {
         $result[false]= $supplier();
         return $result;
       },
-      function($result, $arg) use($predicate, $accumulator) {
-        $accumulator($result[$predicate($arg)], $arg);
+      function($result, $arg) use($func, $accumulator) {
+        $accumulator($result[$func($arg)], $arg);
       }
     );
   }

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -171,7 +171,7 @@ final class Collectors extends \lang\Object {
         return $result;
       },
       function($result, $arg) use($func, $accumulator) {
-        $accumulator($result[$func($arg)], $arg);
+        $accumulator($result[(bool)$func($arg)], $arg);
       }
     );
   }

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -186,10 +186,11 @@ final class Collectors extends \lang\Object {
     if (null === $collector) $collector= self::toList();
     $accumulator= $collector->accumulator();
 
+    $func= Functions::$APPLY->newInstance($mapper);
     return new Collector(
       $collector->supplier(),
-      function($result, $arg) use($mapper, $accumulator) {
-        $accumulator($result, $mapper($arg));
+      function($result, $arg) use($func, $accumulator) {
+        $accumulator($result, $func($arg));
       }
     );
   }
@@ -205,7 +206,8 @@ final class Collectors extends \lang\Object {
     if (null === $num) {
       $accumulator= function(&$result, $arg) use($num) { $result+= $arg; };
     } else {
-      $accumulator= function(&$result, $arg) use($num) { $result+= $num($arg); }; 
+      $func= Functions::$APPLY->newInstance($num);
+      $accumulator= function(&$result, $arg) use($func) { $result+= $func($arg); }; 
     }
 
     return new Collector(
@@ -226,7 +228,8 @@ final class Collectors extends \lang\Object {
     if (null === $num) {
       $accumulator= function(&$result, $arg) use($num) { $result[0]+= $arg; $result[1]++;  };
     } else {
-      $accumulator= function(&$result, $arg) use($num) { $result[0]+= $num($arg); $result[1]++;  }; 
+      $func= Functions::$APPLY->newInstance($num);
+      $accumulator= function(&$result, $arg) use($func) { $result[0]+= $func($arg); $result[1]++;  }; 
     }
 
     return new Collector(

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -20,10 +20,13 @@ final class Collectors extends \lang\Object {
    * @return util.data.ICollector
    */
   public static function toList($value= null) {
-    return new Collector(function() { return new Vector(); }, null === $value
-      ? function($result, $arg) { $result->add($arg); }
-      : function($result, $arg) use($value) { $result->add($value($arg)); }
-    );
+    if (null === $value) {
+      $accumulator= function($result, $arg) { $result->add($arg); };
+    } else {
+      $func= Functions::$APPLY->newInstance($value);
+      $accumulator= function($result, $arg) use($func) { $result->add($func($arg)); };
+    }
+    return new Collector(function() { return new Vector(); }, $accumulator);
   }
 
   /**
@@ -33,10 +36,13 @@ final class Collectors extends \lang\Object {
    * @return util.data.ICollector
    */
   public static function toSet($value= null) {
-    return new Collector(function() { return new HashSet(); }, null === $value
-      ? function($result, $arg) { $result->add($arg); }
-      : function($result, $arg) use($value) { $result->add($value($arg)); }
-    );
+    if (null === $value) {
+      $accumulator= function($result, $arg) { $result->add($arg); };
+    } else {
+      $func= Functions::$APPLY->newInstance($value);
+      $accumulator= function($result, $arg) use($func) { $result->add($func($arg)); };
+    }
+    return new Collector(function() { return new HashSet(); }, $accumulator);
   }
 
   /**
@@ -66,19 +72,23 @@ final class Collectors extends \lang\Object {
         function($result, $arg, $key) { $result->put($key, $arg); }
       );
     } else if (null === $key) {
+      $v= Functions::$APPLY->newInstance($value);
       return new Collector(
         function() { return new HashTable(); },
-        function($result, $arg, $key) use($value) { $result->put($key, $value($arg)); }
+        function($result, $arg, $key) use($v) { $result->put($key, $v($arg)); }
       );
     } else if (null === $value) {
+      $k= Functions::$APPLY->newInstance($key);
       return new Collector(
         function() { return new HashTable(); },
-        function($result, $arg) use($key) { $result->put($key($arg), $arg); }
+        function($result, $arg) use($k) { $result->put($k($arg), $arg); }
       );
     } else {
+      $k= Functions::$APPLY->newInstance($key);
+      $v= Functions::$APPLY->newInstance($value);
       return new Collector(
         function() { return new HashTable(); },
-        function($result, $arg) use($key, $value) { $result->put($key($arg), $value($arg)); }
+        function($result, $arg) use($k, $v) { $result->put($k($arg), $v($arg)); }
       );
     }
   }

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -186,9 +186,9 @@ final class Collectors extends \lang\Object {
    */
   public static function mapping($mapper, ICollector $collector= null) {
     if (null === $collector) $collector= self::toList();
+    $func= Functions::$APPLY->newInstance($mapper);
     $accumulator= $collector->accumulator();
 
-    $func= Functions::$APPLY->newInstance($mapper);
     return new Collector(
       $collector->supplier(),
       function($result, $arg) use($func, $accumulator) {

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -102,6 +102,7 @@ final class Collectors extends \lang\Object {
    */
   public static function groupingBy($classifier, ICollector $collector= null) {
     if (null === $collector) $collector= self::toList();
+    $func= Functions::$APPLY->cast($classifier);
     $supplier= $collector->supplier();
     $accumulator= $collector->accumulator();
     $finisher= $collector->finisher();
@@ -120,8 +121,8 @@ final class Collectors extends \lang\Object {
     if ($f->getNumberOfParameters() > 1 && $f->getParameters()[0]->isPassedByReference()) {
       return new Collector(
         $return,
-        function($result, $arg) use($classifier, $supplier, $accumulator) {
-          $key= $classifier($arg);
+        function($result, $arg) use($func, $supplier, $accumulator) {
+          $key= $func($arg);
           if ($result->containsKey($key)) {
             $value= $result->get($key);
           } else {
@@ -135,8 +136,8 @@ final class Collectors extends \lang\Object {
     } else {
       return new Collector(
         $return,
-        function($result, $arg) use($classifier, $supplier, $accumulator) {
-          $key= $classifier($arg);
+        function($result, $arg) use($func, $supplier, $accumulator) {
+          $key= $func($arg);
           if ($result->containsKey($key)) {
             $accumulator($result->get($key), $arg);
           } else {

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -46,6 +46,22 @@ class CollectorsTest extends \unittest\TestCase {
     ];
   }
 
+  /** @return var[][] */
+  private function employeesDepartment() {
+    return [
+      [function($e) { return $e->department(); }],
+      [[Employee::class, 'department']]
+    ];
+  }
+
+  /** @return var[][] */
+  private function employeesYears() {
+    return [
+      [function($e) { return $e->years(); }],
+      [[Employee::class, 'years']]
+    ];
+  }
+
   #[@test, @values('employeesName')]
   public function toList($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
@@ -143,32 +159,32 @@ class CollectorsTest extends \unittest\TestCase {
     $this->assertEquals(['COLOR' => 'green', 'PRICE' => 12.99], $result);
   }
 
-  #[@test]
-  public function summing_years() {
+  #[@test, @values('employeesYears')]
+  public function summing_years($yearsOf) {
     $this->assertEquals(33, Sequence::of($this->people)
-      ->collect(Collectors::summing(function($e) { return $e->years(); }))
+      ->collect(Collectors::summing($yearsOf))
     );
   }
 
-  #[@test]
-  public function summing_elements() {
+  #[@test, @values('employeesYears')]
+  public function summing_elements($yearsOf) {
     $this->assertEquals(33, Sequence::of($this->people)
-      ->map(function($e) { return $e->years(); })
+      ->map($yearsOf)
       ->collect(Collectors::summing())
     );
   }
 
-  #[@test]
-  public function averaging_years() {
+  #[@test, @values('employeesYears')]
+  public function averaging_years($yearsOf) {
     $this->assertEquals(11, Sequence::of($this->people)
-      ->collect(Collectors::averaging(function($e) { return $e->years(); }))
+      ->collect(Collectors::averaging($yearsOf))
     );
   }
 
-  #[@test]
-  public function averaging_elements() {
+  #[@test, @values('employeesYears')]
+  public function averaging_elements($yearsOf) {
     $this->assertEquals(11, Sequence::of($this->people)
-      ->map(function($e) { return $e->years(); })
+      ->map($yearsOf)
       ->collect(Collectors::averaging())
     );
   }
@@ -180,10 +196,10 @@ class CollectorsTest extends \unittest\TestCase {
     );
   }
 
-  #[@test]
-  public function mapping_by_department() {
+  #[@test, @values('employeesDepartment')]
+  public function mapping_by_department($departmentOf) {
     $this->assertEquals(new Vector(['B', 'I', 'I']), Sequence::of($this->people)
-      ->collect(Collectors::mapping(function($e) { return $e->department(); }))
+      ->collect(Collectors::mapping($departmentOf))
     );
   }
 

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -62,6 +62,14 @@ class CollectorsTest extends \unittest\TestCase {
     ];
   }
 
+  /** @return var[][] */
+  private function dinosaurEmployees() {
+    return [
+      [function($e) { return $e->years() > 10; }],
+      [[Employee::class, 'isDinosaur']]
+    ];
+  }
+
   #[@test, @values('employeesName')]
   public function toList($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
@@ -255,11 +263,11 @@ class CollectorsTest extends \unittest\TestCase {
     );
   }
 
-  #[@test]
-  public function partitioningBy() {
+  #[@test, @values('dinosaurEmployees')]
+  public function partitioningBy($moreThanTen) {
     $this->assertHashTable(
       [true => new Vector([$this->people[1549], $this->people[1552]]), false => new Vector([$this->people[6100]])],
-      Sequence::of($this->people)->collect(Collectors::partitioningBy(function($e) { return $e->years() > 10; }))
+      Sequence::of($this->people)->collect(Collectors::partitioningBy($moreThanTen))
     );
   }
 }

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -270,4 +270,14 @@ class CollectorsTest extends \unittest\TestCase {
       Sequence::of($this->people)->collect(Collectors::partitioningBy($moreThanTen))
     );
   }
+
+  #[@test]
+  public function partitioningBy_handles_non_booleans() {
+    $this->assertHashTable(
+      [true => new Vector(['Test', 'Unittest']), false => new Vector(['Trial & Error'])],
+      Sequence::of(['Test', 'Unittest', 'Trial & Error'])->collect(Collectors::partitioningBy(function($e) {
+        return stristr($e, 'Test');
+      }))
+    );
+  }
 }

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -9,7 +9,7 @@ use util\collections\HashTable;
 use lang\XPClass;
 
 class CollectorsTest extends \unittest\TestCase {
-  protected $people;
+  private $people;
 
   /**
    * Sets up test, initializing people member
@@ -29,7 +29,7 @@ class CollectorsTest extends \unittest\TestCase {
    * @param  util.collections.HashTable $actual
    * @throws unittest.AssertionFailedError
    */
-  protected function assertHashTable($expected, $actual) {
+  private function assertHashTable($expected, $actual) {
     $this->assertInstanceOf(HashTable::class, $actual);
     $compare= [];
     foreach ($actual as $pair) {
@@ -38,51 +38,59 @@ class CollectorsTest extends \unittest\TestCase {
     return $this->assertEquals($expected, $compare);
   }
 
-  #[@test]
-  public function toList() {
+  /** @return var[][] */
+  private function employeesName() {
+    return [
+      [function($e) { return $e->name(); }],
+      [[Employee::class, 'name']]
+    ];
+  }
+
+  #[@test, @values('employeesName')]
+  public function toList($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
-      ->map(function($e) { return $e->name(); })
+      ->map($nameOf)
       ->collect(Collectors::toList())
       ->elements()
     );
   }
 
-  #[@test]
-  public function toList_with_extraction() {
+  #[@test, @values('employeesName')]
+  public function toList_with_extraction($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
-      ->collect(Collectors::toList(function($e) { return $e->name(); }))
+      ->collect(Collectors::toList($nameOf))
       ->elements()
     );
   }
 
-  #[@test]
-  public function toSet() {
+  #[@test, @values('employeesName')]
+  public function toSet($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
-      ->map(function($e) { return $e->name(); })
+      ->map($nameOf)
       ->collect(Collectors::toSet())
       ->toArray()
     );
   }
 
-  #[@test]
-  public function toSet_with_extraction() {
+  #[@test, @values('employeesName')]
+  public function toSet_with_extraction($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
-      ->collect(Collectors::toSet(function($e) { return $e->name(); }))
+      ->collect(Collectors::toSet($nameOf))
       ->toArray()
     );
   }
 
-  #[@test]
-  public function toCollection_with_HashSet_class() {
+  #[@test, @values('employeesName')]
+  public function toCollection_with_HashSet_class($nameOf) {
     $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
-      ->map(function($e) { return $e->name(); })
+      ->map($nameOf)
       ->collect(Collectors::toCollection(XPClass::forName('util.collections.HashSet')))
       ->toArray()
     );
   }
 
-  #[@test]
-  public function toMap() {
+  #[@test, @values('employeesName')]
+  public function toMap($nameOf) {
     $map= new HashTable();
     $map[1549]= 'Timm';
     $map[1552]= 'Alex';
@@ -90,19 +98,20 @@ class CollectorsTest extends \unittest\TestCase {
 
     $this->assertEquals($map, Sequence::of($this->people)->collect(Collectors::toMap(
       function($e) { return $e->id(); },
-      function($e) { return $e->name(); }
+      $nameOf
     )));
   }
 
-  #[@test]
-  public function toMap_uses_complete_value_if_value_function_omitted() {
+  #[@test, @values('employeesName')]
+  public function toMap_uses_complete_value_if_value_function_omitted($nameOf) {
     $map= new HashTable();
     $map['Timm']= $this->people[1549];
     $map['Alex']= $this->people[1552];
     $map['Dude']= $this->people[6100];
 
     $this->assertEquals($map, Sequence::of($this->people)->collect(Collectors::toMap(
-      function($e) { return $e->name(); }
+      $nameOf,
+      null
     )));
   }
 

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -227,11 +227,11 @@ class CollectorsTest extends \unittest\TestCase {
     );
   }
 
-  #[@test]
-  public function groupingBy() {
+  #[@test, @values('employeesDepartment')]
+  public function groupingBy($departmentOf) {
     $this->assertHashTable(
       ['B' => new Vector([$this->people[1549]]), 'I' => new Vector([$this->people[1552], $this->people[6100]])],
-      Sequence::of($this->people)->collect(Collectors::groupingBy(function($e) { return $e->department(); }))
+      Sequence::of($this->people)->collect(Collectors::groupingBy($departmentOf))
     );
   }
 

--- a/src/test/php/util/data/unittest/Employee.class.php
+++ b/src/test/php/util/data/unittest/Employee.class.php
@@ -33,6 +33,9 @@ class Employee extends \lang\Object {
   /** @return int */
   public function years() { return $this->years; }
 
+  /** @return bool */
+  public function isDinosaur() { return $this->years > 10; }
+
   /**
    * Creates a string representation
    *


### PR DESCRIPTION
Prevents fatal errors when using [$class, $method] notation and referencing a non-static method, which PHP does not support but the XP Framework does!

```php
// Worked before
$names= Sequence::of($people)
  ->map([Person::class, 'name'])
  ->collect(Collectors::toList())
  ->elements()
;

// Now also works, previously caused fatal error
$names= Sequence::of($people)
  ->collect(Collectors::toList([Person::class, 'name']))
  ->elements()
;
```

See also #27