### PR TITLE
Add optional filter to first() operation

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -144,9 +144,9 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
         if (isset($instance->elements->closed)) {
           throw new IllegalStateException('Generator closed');
         }
-        if ($instance->elements->valid()) {
+        foreach ($instance->elements as $element) {
           $instance->elements->closed= true;
-          return new Optional($instance->elements->current());
+          return new Optional($element);
         }
       } else {
         foreach ($instance->elements as $element) {

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -137,16 +137,23 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @return util.data.Optional
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
-  public function first() {
-    return $this->terminal(function() {
-      $gen= $this->elements instanceof \Generator;
-      if ($gen && isset($this->elements->closed)) {
-        throw new IllegalStateException('Generator closed');
+  public function first($filter= null) {
+    $instance= $filter ? $this->filter($filter) : $this;
+    return $this->terminal(function() use($instance) {
+      if ($instance->elements instanceof \Generator) {
+        if (isset($instance->elements->closed)) {
+          throw new IllegalStateException('Generator closed');
+        }
+        if ($instance->elements->valid()) {
+          $instance->elements->closed= true;
+          return new Optional($instance->elements->current());
+        }
+      } else {
+        foreach ($instance->elements as $element) {
+          return new Optional($element);
+        }
       }
-      foreach ($this->elements as $element) {
-        $gen && $this->elements->closed= true;
-        return new Optional($element);
-      }
+
       return Optional::$EMPTY;
     });
   }

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -80,6 +80,11 @@ class SequenceTest extends AbstractSequenceTest {
     $this->assertEquals(2, Sequence::of([1, 2, 3])->first(function($i) { return 0 === $i % 2; })->get());
   }
 
+  #[@test]
+  public function first_returns_non_present_optional_if_no_element_matches_its_filter() {
+    $this->assertFalse(Sequence::of([1, 3])->first(function($i) { return 0 === $i % 2; })->present());
+  }
+
   #[@test, @values([
   #  [[1, 2, 3], [1, 2, 2, 3, 1, 3]],
   #  [[new Name('a'), new Name('b')], [new Name('a'), new Name('a'), new Name('b')]]

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -75,6 +75,11 @@ class SequenceTest extends AbstractSequenceTest {
     $this->assertEquals(1, Sequence::of([1, 2, 3])->first()->get());
   }
 
+  #[@test]
+  public function first_returns_first_element_to_match_its_filter() {
+    $this->assertEquals(2, Sequence::of([1, 2, 3])->first(function($i) { return 0 === $i % 2; })->get());
+  }
+
   #[@test, @values([
   #  [[1, 2, 3], [1, 2, 2, 3, 1, 3]],
   #  [[new Name('a'), new Name('b')], [new Name('a'), new Name('a'), new Name('b')]]


### PR DESCRIPTION
Writing `$seq->first($filter)` becomes a shorthand for `$seq->filter($filter)->first()`

## .NET
The `Enumerable.First` method has an overload `IEnumerable<TSource>, Func<TSource, Boolean>`:
https://msdn.microsoft.com/de-de/library/bb535050(v=vs.110).aspx

## Scala
Scala has a method defined as `find(p: (A) ⇒ Boolean): Option[A]` (*"finds the first element of the iterable collection satisfying a predicate, if any"*). 

## Groovy
...has find (with predicate) and first (no-args) operations.