### PR TITLE
Add optional "function" parameter to distinct()

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -463,16 +463,16 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    */
   public function distinct($function= null) {
     $hash= Functions::$APPLY->newInstance($function ?: 'util.Objects::hashOf');
-    $set= [];
-    return new self(new \CallbackFilterIterator($this->getIterator(), function($e) use(&$set, $hash) {
-      $h= $hash($e);
-      if (isset($set[$h])) {
-        return false;
-      } else {
-        $set[$h]= true;
-        return true;
+    return self::of(function() use($hash) {
+      $set= [];
+      foreach ($this->elements as $e) {
+        $h= $hash($e);
+        if (!isset($set[$h])) {
+          $set[$h]= true;
+          yield $e;
+        }
       }
-    }));
+    });
   }
 
   /**

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -458,12 +458,14 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Returns a stream with distinct elements
    *
+   * @param  function(var): var $function - if omitted, `util.Objects::hashOf()` is used
    * @return self
    */
-  public function distinct() {
+  public function distinct($function= null) {
+    $hash= Functions::$APPLY->newInstance($function ?: 'util.Objects::hashOf');
     $set= [];
-    return new self(new \CallbackFilterIterator($this->getIterator(), function($e) use(&$set) {
-      $h= Objects::hashOf($e);
+    return new self(new \CallbackFilterIterator($this->getIterator(), function($e) use(&$set, $hash) {
+      $h= $hash($e);
       if (isset($set[$h])) {
         return false;
       } else {

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -93,6 +93,16 @@ class SequenceTest extends AbstractSequenceTest {
     $this->assertSequence($result, Sequence::of($input)->distinct());
   }
 
+  #[@test, @values([
+  #  function($record) { return $record['id']; }
+  #])]
+  public function distinct_with($function) {
+    $this->assertSequence(
+      [['id' => 1, 'name' => 'Timm']],
+      Sequence::of([['id' => 1, 'name' => 'Timm'], ['id' => 1]])->distinct($function)
+    );
+  }
+
   #[@test]
   public function is_useable_inside_foreach() {
     $this->assertEquals([1, 2, 3], iterator_to_array(Sequence::of([1, 2, 3])));


### PR DESCRIPTION
Allows to specify function other than `util.Objects::hashOf` to calculate hash of a given record.