### PR TITLE
Add ability to use yield statements inside flatten()

### DIFF
--- a/src/main/php/util/data/AbstractMapper.class.php
+++ b/src/main/php/util/data/AbstractMapper.class.php
@@ -5,7 +5,7 @@
  * iterator returns and returns its result.
  */
 abstract class AbstractMapper extends \lang\Object implements \Iterator {
-  protected $it, $func;
+  protected $it, $func, $yieldMap;
   private $current, $key, $valid;
 
   /**
@@ -13,10 +13,12 @@ abstract class AbstractMapper extends \lang\Object implements \Iterator {
    *
    * @param  php.Mapper $it
    * @param  php.Closure $func
+   * @param  bool $yieldMap Whether yield $key => $value should be used to create maps
    */
-  public function __construct(\Iterator $it, \Closure $func) {
+  public function __construct(\Iterator $it, \Closure $func, $yieldMap= true) {
     $this->it= $it;
     $this->func= $func;
+    $this->yieldMap= $yieldMap;
   }
 
   /** @return var */
@@ -26,7 +28,7 @@ abstract class AbstractMapper extends \lang\Object implements \Iterator {
   protected function forward() {
     if ($this->valid= $this->it->valid()) {
       $result= $this->map();
-      if ($result instanceof \Generator) {
+      if ($this->yieldMap && $result instanceof \Generator) {
         foreach ($result as $this->key => $this->current) { }
       } else {
         $this->key= $this->it->key();

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -393,9 +393,9 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
     if (null === $function) {
       $it= $this->getIterator();
     } else if (Functions::$APPLY_WITH_KEY->isInstance($function)) {
-      $it= new MapperWithKey($this->getIterator(), Functions::$APPLY_WITH_KEY->cast($function));
+      $it= new MapperWithKey($this->getIterator(), Functions::$APPLY_WITH_KEY->cast($function), false);
     } else {
-      $it= new Mapper($this->getIterator(), Functions::$APPLY->newInstance($function));
+      $it= new Mapper($this->getIterator(), Functions::$APPLY->newInstance($function), false);
     }
     return new self(new Flattener($it));
   }

--- a/src/test/php/util/data/unittest/Enumerables.class.php
+++ b/src/test/php/util/data/unittest/Enumerables.class.php
@@ -15,11 +15,6 @@ use util\data\Sequence;
  * @see   php://generators
  */
 abstract class Enumerables extends Object {
-  private static $generators;
-
-  static function __static() {
-    self::$generators= class_exists('Generator', false);
-  }
 
   /**
    * Returns valid arguments for the `of()` method.
@@ -32,7 +27,7 @@ abstract class Enumerables extends Object {
 
   /**
    * Returns valid arguments for the `of()` method: Arrays, iterables, 
-   * iterators and generators (the latter only if available).
+   * iterators and generators.
    *
    * @return var[][]
    */
@@ -42,7 +37,7 @@ abstract class Enumerables extends Object {
 
   /**
    * Returns valid arguments for the `of()` method: Maps, iterables, 
-   * iterators and generators (the latter only if available).
+   * iterators and generators.
    *
    * @return var[][]
    */
@@ -70,24 +65,21 @@ abstract class Enumerables extends Object {
    * @return var[][]
    */
   public static function streamedArrays() {
-    return array_merge(
-      self::$generators ? [
-        [eval('return function() { yield 1; yield 2; yield 3; };'), 'closure'],
-        [eval('$f= function() { yield 1; yield 2; yield 3; }; return $f();'), 'generator']
-      ] : [],
-      [
-        [newinstance(XPIterator::class, [], '{
-          protected $numbers= [1, 2, 3];
-          public function hasNext() { return !empty($this->numbers); }
-          public function next() { return array_shift($this->numbers); }
-        }'), 'xp-iterator'],
-        [Sequence::of(newinstance(XPIterator::class, [], '{
-          protected $numbers= [1, 2, 3];
-          public function hasNext() { return !empty($this->numbers); }
-          public function next() { return array_shift($this->numbers); }
-        }')), 'self-of-xp-iterator']
-      ]
-    );
+    $f= function() { yield 1; yield 2; yield 3; };
+    return [
+      [$f, 'closure'],
+      [$f(), 'generator'],
+      [newinstance(XPIterator::class, [], '{
+        protected $numbers= [1, 2, 3];
+        public function hasNext() { return !empty($this->numbers); }
+        public function next() { return array_shift($this->numbers); }
+      }'), 'xp-iterator'],
+      [Sequence::of(newinstance(XPIterator::class, [], '{
+        protected $numbers= [1, 2, 3];
+        public function hasNext() { return !empty($this->numbers); }
+        public function next() { return array_shift($this->numbers); }
+      }')), 'self-of-xp-iterator']
+    ];
   }
 
   /**
@@ -110,10 +102,8 @@ abstract class Enumerables extends Object {
    * @return var[][]
    */
   public static function streamedMaps() {
-    return self::$generators ? [
-      [eval('return function() { yield "color" => "green"; yield "price" => 12.99; };'), 'closure'],
-      [eval('$f= function() { yield "color" => "green"; yield "price" => 12.99; }; return $f();'), 'generator']
-    ] : [];
+    $f= function() { yield 'color' => 'green'; yield 'price' => 12.99; };
+    return [[$f, 'closure'], [$f(), 'generator']];
   }
   /**
    * Returns invalid arguments for the `of()` method: Primitives, non-iterable

--- a/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
@@ -44,4 +44,23 @@ class SequenceFlatteningTest extends AbstractSequenceTest {
     Sequence::of(['one' => [1], 'two' => [2], 'three' => [3]])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
     $this->assertEquals(['one', 'two', 'three'], $keys);
   }
+
+  #[@test]
+  public function flatten_generator() {
+    $this->assertSequence([2, 4, 0, 4, 1], Sequence::of([2])->flatten(function($n) {
+      yield $n;
+      yield $n + $n;
+      yield $n - $n;
+      yield $n * $n;
+      yield $n / $n;
+    }));
+  }
+
+  #[@test]
+  public function flatten_generator_with_key() {
+    $this->assertSequence([3, 6], Sequence::of([1 => 2])->flatten(function($n, $key) {
+      yield $n + $key;
+      yield $n * ($n + $key);
+    }));
+  }
 }

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -44,17 +44,17 @@ class SequenceMappingTest extends AbstractSequenceTest {
     );
   }
 
-  #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
+  #[@test]
   public function with_generator() {
     $records= Sequence::of([['unit' => 'yellow', 'amount' => 20], ['unit' => 'blue', 'amount' => 19]]);
-    $generator= eval('return function($record) { yield $record["unit"] => $record["amount"]; };');
+    $generator= function($record) { yield $record['unit'] => $record['amount']; };
     $this->assertEquals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
   }
 
-  #[@test, @action(new VerifyThat(function() { return class_exists('Generator', false); }))]
+  #[@test]
   public function with_generator_and_key() {
     $records= Sequence::of(['color' => 'green', 'price' => 12.99]);
-    $generator= eval('return function($value, $key) { yield strtoupper($key) => $value; };');
+    $generator= function($value, $key) { yield strtoupper($key) => $value; };
     $this->assertEquals(['COLOR' => 'green', 'PRICE' => 12.99], $records->map($generator)->toMap());
   }
 }


### PR DESCRIPTION
## Example

```php
$rooms= Sequence::of($locations)
  ->flatten(function($location) {
    foreach ($location->rooms() as $room) {
      yield $location->name().' '.$room->name() => $room;
    }
  })
  ->toMap()
;

// [
//   "KA BS 50 1101" => com.example.Room(...),
//   "KA BS 50 1102" => com.example.Room(...)
// ]
```

This extends the *yield* functionality in `map()`, e.g:

```php
$map= Sequence::of($users)
  ->map(function($user) { yield $user->id() => $user; })
  ->toMap()
;

// [
//    1549 => com.example.User("friebe"),
//    1552 => com.example.User("kiesel"),
// ]
```