### PR TITLE
Add util.data.CannotReset class replacing lang.IllegalStateException

### DIFF
--- a/src/main/php/util/data/CannotReset.class.php
+++ b/src/main/php/util/data/CannotReset.class.php
@@ -3,7 +3,7 @@
 /**
  * Indicates the underlying value is streamed and cannot be reset
  *
- * @see   xp://util.data.Sequence#terminal
+ * @see   xp://util.data.Iterator#rewind
  */
 class CannotReset extends \lang\XPException {
 

--- a/src/main/php/util/data/CannotReset.class.php
+++ b/src/main/php/util/data/CannotReset.class.php
@@ -1,0 +1,10 @@
+<?php namespace util\data;
+
+/**
+ * Indicates the underlying value is streamed and cannot be reset
+ *
+ * @see   xp://util.data.Sequence#terminal
+ */
+class CannotReset extends \lang\XPException {
+
+}

--- a/src/main/php/util/data/ContinuationOf.class.php
+++ b/src/main/php/util/data/ContinuationOf.class.php
@@ -6,24 +6,15 @@
  *
  * @test  xp://util.data.unittest.ContinuationOfTest
  */
-class ContinuationOf extends \lang\Object implements \Iterator {
-  private $it;
+class ContinuationOf extends Iterator {
 
-  /** @param php.Iterator $it */
-  public function __construct($it) { $this->it= $it; }
-
-  /** @return var */
-  public function current() { return $this->it->current(); }
-
-  /** @return var */
-  public function key() { return $this->it->key(); }
-
-  /** @return bool */
-  public function valid() { return $this->it->valid(); }
-
-  /** @return void */
-  public function next() { $this->it->next(); }
-
-  /** @return void */
-  public function rewind() { /* NOOP */ }
+  /**
+   * Rewind
+   *
+   * @return void
+   * @throws util.data.CannotReset
+   */
+  public function rewind() {
+    // NOOP
+  }
 }

--- a/src/main/php/util/data/Enumeration.class.php
+++ b/src/main/php/util/data/Enumeration.class.php
@@ -28,12 +28,16 @@ abstract class Enumeration extends \lang\Object {
    * @throws lang.IllegalArgumentException
    */
   public static function of($arg) {
-    if ($arg instanceof \Traversable) {
+    if ($arg instanceof Sequence) {
       return $arg;
+    } else if ($arg instanceof \Generator) {
+      return new YieldingOf($arg);
+    } else if ($arg instanceof \Traversable) {
+      return new TraversalOf($arg);
     } else if ($arg instanceof \Closure) {
       $generator= $arg();
       if ($generator instanceof \Generator) {
-        return $generator;
+        return new YieldingOf($generator);
       }
     } else if ($arg instanceof XPIterator) {
       return new XPIteratorAdapter($arg);

--- a/src/main/php/util/data/Iterator.class.php
+++ b/src/main/php/util/data/Iterator.class.php
@@ -1,0 +1,38 @@
+<?php namespace util\data;
+
+abstract class Iterator implements \Iterator {
+  protected $it;
+
+  /** @param php.Traversable $arg */
+  public function __construct($arg) {
+    $this->it= $arg instanceof \IteratorAggregate ? $arg->getIterator() : $arg;
+  }
+
+  /**
+   * Rewind
+   *
+   * @return void
+   * @throws util.data.CannotReset
+   */
+  public abstract function rewind();
+
+  /** @return string|int */
+  public function key() {
+    return $this->it->key();
+  }
+
+  /** @return var */
+  public function current() {
+    return $this->it->current();
+  }
+
+  /** @return bool */
+  public function valid() {
+    return $this->it->valid();
+  }
+
+  /** @return void */
+  public function next() {
+    $this->it->next();
+  }
+}

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -50,7 +50,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
     try {
       return $operation();
     } catch (CannotReset $e) {
-      throw new CannotReset($message, $e);
+      throw $e;
     } catch (Throwable $e) {
       throw $e;
     } catch (\Throwable $e) {   // PHP7
@@ -61,7 +61,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   }
 
   /** @return util.XPIterator */
-  public function iterator() { return $this->terminal(function() { return new SequenceIterator($this); }); }
+  public function iterator() { return new SequenceIterator($this); }
 
   /**
    * Gets an iterator on this stream. Optimizes the case that the underlying

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -45,19 +45,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws util.data.CannotReset
    */
   protected function terminal($operation) {
-    static $message= 'Underlying value is streamed and cannot be processed more than once';
-
-    try {
-      return $operation();
-    } catch (CannotReset $e) {
-      throw $e;
-    } catch (Throwable $e) {
-      throw $e;
-    } catch (\Throwable $e) {   // PHP7
-      throw new CannotReset($message.':'.$e->getMessage());
-    } catch (\Exception $e) {   // PHP5
-      throw new CannotReset($message.':'.$e->getMessage());
-    }
+    return $operation();
   }
 
   /** @return util.XPIterator */
@@ -138,23 +126,10 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    */
   public function first($filter= null) {
     $instance= $filter ? $this->filter($filter) : $this;
-    return $this->terminal(function() use($instance) {
-      if ($instance->elements instanceof \Generator) {
-        if (isset($instance->elements->closed)) {
-          throw new CannotReset('Generator closed');
-        }
-        foreach ($instance->elements as $element) {
-          $instance->elements->closed= true;
-          return new Optional($element);
-        }
-      } else {
-        foreach ($instance->elements as $element) {
-          return new Optional($element);
-        }
-      }
-
-      return Optional::$EMPTY;
-    });
+    foreach ($instance->elements as $element) {
+      return new Optional($element);
+    }
+    return Optional::$EMPTY;
   }
 
   /**

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -37,17 +37,6 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
     $this->elements= $elements;
   }
 
-  /**
-   * Invoke terminal operation
-   *
-   * @param  function(): var $operation
-   * @return var
-   * @throws util.data.CannotReset
-   */
-  protected function terminal($operation) {
-    return $operation();
-  }
-
   /** @return util.XPIterator */
   public function iterator() { return new SequenceIterator($this); }
 
@@ -139,13 +128,11 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
   public function toArray() {
-    return $this->terminal(function() {
-      $return= [];
-      foreach ($this->elements as $element) {
-        $return[]= $element;
-      }
-      return $return;
-    });
+    $return= [];
+    foreach ($this->elements as $element) {
+      $return[]= $element;
+    }
+    return $return;
   }
 
   /**
@@ -155,13 +142,11 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
   public function toMap() {
-    return $this->terminal(function() {
-      $return= [];
-      foreach ($this->elements as $key => $element) {
-        $return[$key]= $element;
-      }
-      return $return;
-    });
+    $return= [];
+    foreach ($this->elements as $key => $element) {
+      $return[$key]= $element;
+    }
+    return $return;
   }
 
   /**
@@ -171,13 +156,11 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
   public function count() {
-    return $this->terminal(function() {
-      $return= 0;
-      foreach ($this->elements as $element) {
-        $return++;
-      }
-      return $return;
-    });
+    $return= 0;
+    foreach ($this->elements as $element) {
+      $return++;
+    }
+    return $return;
   }
 
   /**
@@ -212,14 +195,12 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
   public function reduce($identity, $accumulator) {
-    return $this->terminal(function() use($identity, $accumulator) {
-      $closure= Functions::$BINARYOP->newInstance($accumulator);
-      $return= $identity;
-      foreach ($this->elements as $element) {
-        $return= $closure($return, $element);
-      }
-      return $return;
-    });
+    $closure= Functions::$BINARYOP->newInstance($accumulator);
+    $return= $identity;
+    foreach ($this->elements as $element) {
+      $return= $closure($return, $element);
+    }
+    return $return;
   }
 
   /**
@@ -230,22 +211,20 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
   public function collect(ICollector $collector) {
-    return $this->terminal(function() use($collector) {
-      $accumulator= $collector->accumulator();
-      $finisher= $collector->finisher();
+    $accumulator= $collector->accumulator();
+    $finisher= $collector->finisher();
 
-      $return= $collector->supplier()->__invoke();
-      if (Functions::$CONSUME_WITH_KEY->isInstance($accumulator)) {
-        foreach ($this->elements as $key => $element) {
-          $accumulator($return, $element, $key);
-        }
-      } else {
-        foreach ($this->elements as $element) {
-          $accumulator($return, $element);
-        }
+    $return= $collector->supplier()->__invoke();
+    if (Functions::$CONSUME_WITH_KEY->isInstance($accumulator)) {
+      foreach ($this->elements as $key => $element) {
+        $accumulator($return, $element, $key);
       }
-      return $finisher ? $finisher($return) : $return;
-    });
+    } else {
+      foreach ($this->elements as $element) {
+        $accumulator($return, $element);
+      }
+    }
+    return $finisher ? $finisher($return) : $return;
   }
 
   /**
@@ -258,35 +237,25 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    */
   public function each($consumer= null, $args= null) {
     if (null !== $args) {
-      $t= function() use($consumer, $args) {
-        $inv= Functions::$APPLY->newInstance($consumer);
-        $i= 0;
-        foreach ($this->elements as $element) { $inv(...array_merge([$element], $args)); $i++; }
-        return $i;
-      };
+      $inv= Functions::$APPLY->newInstance($consumer);
+      $i= 0;
+      foreach ($this->elements as $element) { $inv(...array_merge([$element], $args)); $i++; }
+      return $i;
     } else if (Functions::$APPLY_WITH_KEY->isInstance($consumer)) {
-      $t= function() use($consumer) {
-        $inv= Functions::$APPLY_WITH_KEY->cast($consumer);
-        $i= 0;
-        foreach ($this->elements as $key => $element) { $inv($element, $key); $i++; }
-        return $i;
-      };
+      $inv= Functions::$APPLY_WITH_KEY->cast($consumer);
+      $i= 0;
+      foreach ($this->elements as $key => $element) { $inv($element, $key); $i++; }
+      return $i;
     } else if (null !== $consumer) {
-      $t= function() use($consumer) {
-        $inv= Functions::$APPLY->newInstance($consumer);
-        $i= 0;
-        foreach ($this->elements as $element) { $inv($element); $i++; }
-        return $i;
-      };
+      $inv= Functions::$APPLY->newInstance($consumer);
+      $i= 0;
+      foreach ($this->elements as $element) { $inv($element); $i++; }
+      return $i;
     } else {
-      $t= function() {
-        $i= 0;
-        foreach ($this->elements as $element) { $i++; }
-        return $i;
-      };
-
+      $i= 0;
+      foreach ($this->elements as $element) { $i++; }
+      return $i;
     }
-    return $this->terminal($t);
   }
 
   /**

--- a/src/main/php/util/data/SequenceIterator.class.php
+++ b/src/main/php/util/data/SequenceIterator.class.php
@@ -19,13 +19,7 @@ class SequenceIterator extends \lang\Object implements \util\XPIterator, \Iterat
    */
   public function __construct(Sequence $seq) {
     $this->it= $seq->getIterator();
-    try {
-      $this->it->rewind();
-    } catch (\Throwable $e) {   // PHP7
-      throw new CannotReset($e->getMessage());
-    } catch (\Exception $e) {   // PHP5
-      throw new CannotReset($e->getMessage());
-    }
+    $this->it->rewind();
   }
 
   /**

--- a/src/main/php/util/data/SequenceIterator.class.php
+++ b/src/main/php/util/data/SequenceIterator.class.php
@@ -15,7 +15,7 @@ class SequenceIterator extends \lang\Object implements \util\XPIterator, \Iterat
    * Creates a new iterator over a sequence
    *
    * @param  util.data.Sequence $seq
-   * @throws lang.IllegalStateException If the sequence has been processed
+   * @throws util.data.CannotReset If the sequence has been processed
    */
   public function __construct(Sequence $seq) {
     $this->it= $seq->getIterator();

--- a/src/main/php/util/data/SequenceIterator.class.php
+++ b/src/main/php/util/data/SequenceIterator.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data;
 
 use util\NoSuchElementException;
-use lang\IllegalStateException;
 
 /**
  * Iterates over Sequence instances
@@ -22,8 +21,10 @@ class SequenceIterator extends \lang\Object implements \util\XPIterator, \Iterat
     $this->it= $seq->getIterator();
     try {
       $this->it->rewind();
-    } catch (\Exception $e) {
-      throw new IllegalStateException($e->getMessage());
+    } catch (\Throwable $e) {   // PHP7
+      throw new CannotReset($e->getMessage());
+    } catch (\Exception $e) {   // PHP5
+      throw new CannotReset($e->getMessage());
     }
   }
 

--- a/src/main/php/util/data/TraversalOf.class.php
+++ b/src/main/php/util/data/TraversalOf.class.php
@@ -4,6 +4,8 @@
  * Traversable of a given iteration wrapping exceptions from rewind() in
  * a util.data.CannotReset exceptions to make it distinguishable from other
  * exceptions.
+ *
+ * @test  xp://util.data.unittest.TraversalOfTest
  */
 class TraversalOf extends Iterator {
 

--- a/src/main/php/util/data/TraversalOf.class.php
+++ b/src/main/php/util/data/TraversalOf.class.php
@@ -1,0 +1,25 @@
+<?php namespace util\data;
+
+/**
+ * Traversable of a given iteration wrapping exceptions from rewind() in
+ * a util.data.CannotReset exceptions to make it distinguishable from other
+ * exceptions.
+ */
+class TraversalOf extends Iterator {
+
+  /**
+   * Rewind
+   *
+   * @return void
+   * @throws util.data.CannotReset
+   */
+  public function rewind() {
+    try {
+      $this->it->rewind();
+    } catch (\Throwable $e) {   // PHP7
+      throw new CannotReset($e->getMessage(), $e);
+    } catch (\Exception $e) {   // PHP5
+      throw new CannotReset($e->getMessage(), $e);
+    }
+  }
+}

--- a/src/main/php/util/data/XPIteratorAdapter.class.php
+++ b/src/main/php/util/data/XPIteratorAdapter.class.php
@@ -1,7 +1,5 @@
 <?php namespace util\data;
 
-use lang\IllegalStateException;
-
 /**
  * Adapter class for wrapping an util.XPIterator instance in an iterator
  * useable by PHP.
@@ -34,7 +32,7 @@ class XPIteratorAdapter extends \lang\Object implements \Iterator {
   /** @return void */
   public function rewind() {
     if ($this->key > -1) {
-      throw new IllegalStateException('Cannot rewind iterator');
+      throw new CannotReset('Cannot rewind iterator');
     } else {
       $this->next();
     }

--- a/src/main/php/util/data/YieldingOf.class.php
+++ b/src/main/php/util/data/YieldingOf.class.php
@@ -3,6 +3,8 @@
 /**
  * Special case of traversal wrapper geared towards generators, where
  * rewind() does not fail until the generator was completely yielded.
+ *
+ * @test  xp://util.data.unittest.YieldingOfTest
  */
 class YieldingOf extends Iterator {
   private $started= false;
@@ -18,13 +20,7 @@ class YieldingOf extends Iterator {
       throw new CannotReset('Yielding from generator previously started, cannot rewind');
     }
 
-    try {
-      $this->it->rewind();
-      $this->started= true;
-    } catch (\Throwable $e) {   // PHP7
-      throw new CannotReset($e->getMessage(), $e);
-    } catch (\Exception $e) {   // PHP5
-      throw new CannotReset($e->getMessage(), $e);
-    }
+    $this->it->rewind();
+    $this->started= true;
   }
 }

--- a/src/main/php/util/data/YieldingOf.class.php
+++ b/src/main/php/util/data/YieldingOf.class.php
@@ -1,0 +1,30 @@
+<?php namespace util\data;
+
+/**
+ * Special case of traversal wrapper geared towards generators, where
+ * rewind() does not fail until the generator was completely yielded.
+ */
+class YieldingOf extends Iterator {
+  private $started= false;
+
+  /**
+   * Rewind
+   *
+   * @return void
+   * @throws util.data.CannotReset
+   */
+  public function rewind() {
+    if ($this->started) {
+      throw new CannotReset('Yielding from generator previously started, cannot rewind');
+    }
+
+    try {
+      $this->it->rewind();
+      $this->started= true;
+    } catch (\Throwable $e) {   // PHP7
+      throw new CannotReset($e->getMessage(), $e);
+    } catch (\Exception $e) {   // PHP5
+      throw new CannotReset($e->getMessage(), $e);
+    }
+  }
+}

--- a/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
@@ -3,7 +3,7 @@
 use util\data\Sequence;
 use util\XPIterator;
 use util\NoSuchElementException;
-use lang\IllegalStateException;
+use util\data\CannotReset;
 
 class SequenceIteratorTest extends AbstractSequenceTest {
 
@@ -59,8 +59,8 @@ class SequenceIteratorTest extends AbstractSequenceTest {
     $this->iterated($seq->iterator());
     try {
       $this->iterated($seq->iterator());
-      $this->fail('No exception raised', null, 'lang.IllegalStateException');
-    } catch (IllegalStateException $expected) {
+      $this->fail('No exception raised', null, 'util.data.CannotReset');
+    } catch (CannotReset $expected) {
       // OK
     }
   }

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -4,7 +4,7 @@ use util\cmd\Console;
 use util\data\Sequence;
 use util\data\Optional;
 use util\data\Collector;
-use lang\IllegalStateException;
+use util\data\CannotReset;
 
 class SequenceTest extends AbstractSequenceTest {
 
@@ -20,8 +20,8 @@ class SequenceTest extends AbstractSequenceTest {
     $func($seq);
     try {
       $func($seq);
-      $this->fail('No exception raised', null, IllegalStateException::class);
-    } catch (IllegalStateException $expected) {
+      $this->fail('No exception raised', null, CannotReset::class);
+    } catch (CannotReset $expected) {
       // OK
     }
   }

--- a/src/test/php/util/data/unittest/TraversalOfTest.class.php
+++ b/src/test/php/util/data/unittest/TraversalOfTest.class.php
@@ -43,4 +43,23 @@ class TraversalOfTest extends \unittest\TestCase {
       // OK
     }
   }
+
+  #[@test]
+  public function exceptions_during_iteration_are_left_untouched() {
+    $fixture= new TraversalOf(newinstance(\Iterator::class, [], [
+      'rewind'  => function() { },
+      'current' => function() { throw new IllegalStateException('Test'); },
+      'key'     => function() { return null; },
+      'valid'   => function() { return true; },
+      'next'    => function() { }
+    ]));
+    $fixture->rewind();
+
+    try {
+      $fixture->current();
+      $this->fail('Expected exception not caught', null, IllegalStateException::class);
+    } catch (IllegalStateException $expected) {
+      // OK
+    }
+  }
 }

--- a/src/test/php/util/data/unittest/TraversalOfTest.class.php
+++ b/src/test/php/util/data/unittest/TraversalOfTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace util\data\unittest;
+
+use util\data\TraversalOf;
+use util\data\CannotReset;
+use lang\IllegalStateException;
+
+class TraversalOfTest extends \unittest\TestCase {
+
+  #[@test, @values([
+  #  [[]],
+  #  [[1, 2, 3]],
+  #  [['key' => 'value']]
+  #])]
+  public function iteration($input) {
+    $this->assertEquals($input, iterator_to_array(new TraversalOf(new \ArrayIterator($input))));
+  }
+
+  #[@test, @values([
+  #  [\Exception::class],
+  #  [CannotReset::class],
+  #  [IllegalStateException::class]
+  #])]
+  public function exceptions_from_rewind_are_wrapped_in_cannot_reset($class) {
+    $fixture= new TraversalOf(newinstance(\Iterator::class, [], [
+      'started' => false,
+      'rewind' => function() use($class) {
+        if ($this->started) {
+          throw new $class('Cannot reset');
+        }
+        $this->started= true;
+      },
+      'current' => function() { return null; },
+      'key'     => function() { return null; },
+      'valid'   => function() { return false; },
+      'next'    => function() { }
+    ]));
+    $fixture->rewind();
+
+    try {
+      $fixture->rewind();
+      $this->fail('Expected exception not caught', null, CannotReset::class);
+    } catch (CannotReset $expected) {
+      // OK
+    }
+  }
+}

--- a/src/test/php/util/data/unittest/YieldingOfTest.class.php
+++ b/src/test/php/util/data/unittest/YieldingOfTest.class.php
@@ -1,0 +1,46 @@
+<?php namespace util\data\unittest;
+
+use util\data\YieldingOf;
+use util\data\CannotReset;
+
+class YieldingOfTest extends \unittest\TestCase {
+
+  /** @return iterable */
+  private function fixtures() {
+    yield [function() { yield; }, [null]];
+    yield [function() { yield 1; }, [1]];
+    yield [function() { yield 1; yield 2; }, [1, 2]];
+    yield [function() { yield 'key' => 'value'; }, ['key' => 'value']];
+  }
+
+  #[@test, @values('fixtures')]
+  public function iteration($generator, $expected) {
+    $this->assertEquals($expected, iterator_to_array(new YieldingOf($generator())));
+  }
+
+  #[@test, @values('fixtures')]
+  public function cannot_rewind_after_rewind($generator) {
+    $fixture= new YieldingOf($generator());
+    $fixture->rewind();
+
+    try {
+      $fixture->rewind();
+      $this->fail('Expected exception not caught', null, CannotReset::class);
+    } catch (CannotReset $expected) {
+      // OK
+    }
+  }
+
+  #[@test, @values('fixtures')]
+  public function cannot_rewind_after_complete_iteration($generator) {
+    $fixture= new YieldingOf($generator());
+    iterator_to_array($fixture);
+
+    try {
+      $fixture->rewind();
+      $this->fail('Expected exception not caught', null, CannotReset::class);
+    } catch (CannotReset $expected) {
+      // OK
+    }
+  }
+}


### PR DESCRIPTION
This way, userland code throwing IllegalStateExceptions will not be confused with exceptions raised when resetting streamed sequence sources

```php
$seq= Sequence::of(new SocketInput($socket));

// First iteration, reads data off of socket
$result= $seq->map(...)->filter(...)->toArray();

// Second iteration, not possible here, seeking a socket doesn't work!
try {
  $seq->each();
} catch (CannotReset $expected) {
  // This used to be catch (IllegalStateException $expected). Lots of code in the framework
  // raises this generic exception, so catching it is ambiguous - only the cause will tell!
}
```

//cc @mikey179