### PR TITLE
Add optional mapper to toArray() and toMap()

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -125,12 +125,14 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Collects all elements in an array
    *
+   * @param  function(var): var $map An optional mapper
    * @return var[]
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
-  public function toArray() {
+  public function toArray($map= null) {
+    $instance= $map ? $this->map($map) : $this;
     $return= [];
-    foreach ($this->elements as $element) {
+    foreach ($instance->elements as $element) {
       $return[]= $element;
     }
     return $return;
@@ -139,12 +141,14 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Collects all elements in a map
    *
+   * @param  function(var): var $map An optional mapper
    * @return [:var]
    * @throws lang.IllegalArgumentException if streamed and invoked more than once
    */
-  public function toMap() {
+  public function toMap($map= null) {
+    $instance= $map ? $this->map($map) : $this;
     $return= [];
-    foreach ($this->elements as $key => $element) {
+    foreach ($instance->elements as $key => $element) {
       $return[$key]= $element;
     }
     return $return;

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -42,6 +42,14 @@ class SequenceTest extends AbstractSequenceTest {
   }
 
   #[@test]
+  public function toArray_optionally_accepts_mapper() {
+    $this->assertEquals(
+      [2, 4],
+      Sequence::of([1, 2])->toArray(function($v) { return $v * 2; })
+    );
+  }
+
+  #[@test]
   public function toMap_for_empty_sequence() {
     $this->assertEquals([], Sequence::$EMPTY->toMap());
   }
@@ -49,6 +57,14 @@ class SequenceTest extends AbstractSequenceTest {
   #[@test, @values('util.data.unittest.Enumerables::validMaps')]
   public function toMap_returns_elements_as_map($input) {
     $this->assertEquals(['color' => 'green', 'price' => 12.99], Sequence::of($input)->toMap());
+  }
+
+  #[@test]
+  public function toMap_optionally_accepts_mapper() {
+    $this->assertEquals(
+      ['a' => 2, 'b' => 4],
+      Sequence::of(['a' => 1, 'b' => 2])->toMap(function($v) { return $v * 2; })
+    );
   }
 
   #[@test, @values([


### PR DESCRIPTION
Shortens *map -> toMap* to just a single *toMap* from the outside:

```php
// Before
$exists= Sequence::of($conn->query('...'))
  ->map(function($record) { yield $record['id'] => true; })
  ->toMap()
;

// After
$exists= Sequence::of($conn->query('...'))->toMap(function($_) { yield $_['id'] => true; });
```