### PR TITLE
Replace static concat() w/ multiple-argument of() and append()

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -57,15 +57,15 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * Creates a new stream with an enumeration of elements
    *
    * @see    xp://util.data.Enumeration
-   * @param  var $elements an iterator, iterable, generator or array
+   * @param  var... $enumerations an iterator, iterable, generator or array
    * @return self
    * @throws lang.IllegalArgumentException if type of elements argument is incorrect
    */
-  public static function of($elements) {
-    if (null === $elements) {
-      return self::$EMPTY;
+  public static function of(... $enumerations) {
+    if (sizeof($enumerations) > 1) {
+      return new self(new Iterators($enumerations));
     } else {
-      return new self(Enumeration::of($elements));
+      return null === $enumerations[0] ? self::$EMPTY : new self(Enumeration::of($enumerations[0]));
     }
   }
 
@@ -100,6 +100,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Concatenates all given iteration sources
    *
+   * @deprecated Use of() with multiple arguments instead!
    * @param  var... $args An iterator, iterable or an array
    * @return self
    */

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -70,6 +70,23 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
+   * Appends another enumeration and returns a new stream
+   *
+   * @param  var $enumeration an iterator, iterable, generator or array
+   * @return self
+   * @throws lang.IllegalArgumentException if type of elements argument is incorrect
+   */
+  public function append($enumeration) {
+    if (null === $enumeration) {
+      return $this;
+    } else if ([] === $this->elements) {
+      return self::of($enumeration);
+    } else {
+      return new self($this, $enumeration);
+    }
+  }
+
+  /**
    * Creates a new stream iteratively calling the given operation, starting
    * with a given seed, and continuing with op(seed), op(op(seed)), etc.
    *

--- a/src/main/php/util/data/SequenceAppendTest.class.php
+++ b/src/main/php/util/data/SequenceAppendTest.class.php
@@ -1,0 +1,35 @@
+<?php namespace util\data\unittest;
+
+use util\data\Sequence;
+
+class SequenceAppendTest extends AbstractSequenceTest {
+
+  #[@test, @values('util.data.unittest.Enumerables::validArrays')]
+  public function append_sequence_with($value) {
+    $this->assertSequence([5, 6, 1, 2, 3], Sequence::of([5, 6])->append($value));
+  }
+
+  #[@test, @values('util.data.unittest.Enumerables::validArrays')]
+  public function append_empty_with($value) {
+    $this->assertSequence([1, 2, 3], Sequence::$EMPTY->append($value));
+  }
+
+  #[@test]
+  public function append_null() {
+    $this->assertSequence([1, 2, 3], Sequence::of([1, 2, 3])->append(null));
+  }
+
+  #[@test]
+  public function append_empty() {
+    $this->assertSequence([], Sequence::$EMPTY->append(null));
+  }
+
+  #[@test]
+  public function append_iteratively() {
+    $seq= Sequence::$EMPTY;
+    foreach ([[1, 2], [3, 4], [5, 6]] as $array) {
+      $seq= $seq->append($array);
+    }
+    $this->assertSequence([1, 2, 3, 4, 5, 6], $seq);
+  }
+}

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -11,6 +11,16 @@ use lang\IllegalArgumentException;
  */
 class SequenceCreationTest extends AbstractSequenceTest {
 
+  #[@test]
+  public function of_with_one_argument() {
+    $this->assertSequence([1, 2, 3], Sequence::of([1, 2, 3]));
+  }
+
+  #[@test]
+  public function of_with_multiple_arguments() {
+    $this->assertSequence([1, 2, 3, 4, 5, 6, 7, 8, 9], Sequence::of([1, 2], [3, 4, 5], [6, 7, 8, 9]));
+  }
+
   #[@test, @values('util.data.unittest.Enumerables::valid')]
   public function can_create_via_of($input, $name) {
     $this->assertInstanceOf(Sequence::class, Sequence::of($input), $name);


### PR DESCRIPTION
Using `of()` with multiple arguments:

```php
// Before
$s= Sequence::concat([$topOrgUnit], $childOrgUnits);

// After
$s= Sequence::of([$topOrgUnit], $childOrgUnits);
```

Using `append()`:

```php
// Team leads and admin users have access
$s= Sequence::of($orgUnits)
  ->map(function($orgUnit) { return $orgUnit->leader(); })
  ->append($adminUsers)
  ->toArray()
;