### PR TITLE
Replace static concat() w/ multiple-argument of()

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Sequences can be created from a variety of sources, and by using these static me
 * **of** - accepts PHP arrays (zero-based as well as associative), all traversable data structures including `lang.types.ArrayList` and `lang.types.ArrayMap` as well as anything from `util.collections`, `util.XPIterator` instances, PHP iterators and iterator aggregates, PHP 5.5 generators (*yield*), as well as sequences themselves. Passing NULL will yield an empty sequence.
 * **iterate** - Iterates starting with a given seed, applying a unary operator on this value and passing the result to the next invocation, forever. Combine with `limit()`!
 * **generate** - Iterates forever, returning whatever the given supplier function returns. Combine with `limit()`!
-* **concat** - Concatenates a variable number of arguments with anything `of()` accepts into one large sequence.
 
 Intermediate operations
 -----------------------

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -57,15 +57,15 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * Creates a new stream with an enumeration of elements
    *
    * @see    xp://util.data.Enumeration
-   * @param  var $elements an iterator, iterable, generator or array
+   * @param  var... $enumerations an iterator, iterable, generator or array
    * @return self
    * @throws lang.IllegalArgumentException if type of elements argument is incorrect
    */
-  public static function of($elements) {
-    if (null === $elements) {
-      return self::$EMPTY;
+  public static function of(... $enumerations) {
+    if (sizeof($enumerations) > 1) {
+      return new self(new Iterators($enumerations));
     } else {
-      return new self(Enumeration::of($elements));
+      return null === $enumerations[0] ? self::$EMPTY : new self(Enumeration::of($enumerations[0]));
     }
   }
 
@@ -100,6 +100,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Concatenates all given iteration sources
    *
+   * @deprecated Use of() with multiple arguments instead!
    * @param  var... $args An iterator, iterable or an array
    * @return self
    */

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -11,6 +11,16 @@ use lang\IllegalArgumentException;
  */
 class SequenceCreationTest extends AbstractSequenceTest {
 
+  #[@test]
+  public function of_with_one_argument() {
+    $this->assertSequence([1, 2, 3], Sequence::of([1, 2, 3]));
+  }
+
+  #[@test]
+  public function of_with_multiple_arguments() {
+    $this->assertSequence([1, 2, 3, 4, 5, 6, 7, 8, 9], Sequence::of([1, 2], [3, 4, 5], [6, 7, 8, 9]));
+  }
+
   #[@test, @values('util.data.unittest.Enumerables::valid')]
   public function can_create_via_of($input, $name) {
     $this->assertInstanceOf(Sequence::class, Sequence::of($input), $name);


### PR DESCRIPTION
This pull request deprecates `concat()` (which would then be replaced in 7.0) and replaces it with a version of `of()` with multiple arguments:

```php
// Before
$s= Sequence::concat(Sequence::of([$topOrgUnit]), Sequence::of($childOrgUnits));

// Refactoring is easy: Simply replace concat() with of()
$s= Sequence::of(Sequence::of([$topOrgUnit]), Sequence::of($childOrgUnits));

// Optional next step: Remove Sequence::of() around arguments:
$s= Sequence::of([$topOrgUnit], $childOrgUnits);
```

*Like #37 but without `append()` which can be added separately if necessary*
