### PR TITLE
Inline intermediate operations using `yield`

### DIFF
--- a/src/main/php/util/data/AbstractMapper.class.php
+++ b/src/main/php/util/data/AbstractMapper.class.php
@@ -3,6 +3,8 @@
 /**
  * A mapper reaches applies a given mapper function to each value an
  * iterator returns and returns its result.
+ *
+ * @deprecated
  */
 abstract class AbstractMapper extends \lang\Object implements \Iterator {
   protected $it, $func, $yieldMap;

--- a/src/main/php/util/data/AbstractWindow.class.php
+++ b/src/main/php/util/data/AbstractWindow.class.php
@@ -5,6 +5,7 @@
  * iterator that match its "skip" closure, then returns elements
  * until its "stop" closure is reached.
  *
+ * @deprecated
  * @see   php://LimitIterator but uses closures and not just offsets
  */
 abstract class AbstractWindow extends \lang\Object implements \Iterator {

--- a/src/main/php/util/data/Filterable.class.php
+++ b/src/main/php/util/data/Filterable.class.php
@@ -4,6 +4,7 @@
  * A filterable only returns elements which the given accept function
  * returns true for, omitting the others.
  *
+ * @deprecated
  * @see   php://CallbackFilterIterator but only passes one argument
  * @test  xp://util.data.unittest.FilterableTest
  */

--- a/src/main/php/util/data/FilterableWithKey.class.php
+++ b/src/main/php/util/data/FilterableWithKey.class.php
@@ -4,6 +4,8 @@
  * A filterable only returns elements which the given accept function
  * returns true for, omitting the others.
  *
+ * @deprecated
+ * @test  xp://util.data.unittest.FlattenerTest
  * @see   php://CallbackFilterIterator but only passes two arguments
  */
 class FilterableWithKey extends AbstractFilterable {

--- a/src/main/php/util/data/Flattener.class.php
+++ b/src/main/php/util/data/Flattener.class.php
@@ -5,6 +5,7 @@
  * sequence itself and returns each of its elements before continuing
  * with the iterator's next element.
  *
+ * @deprecated
  * @test  xp://util.data.unittest.FlattenerTest
  */
 class Flattener extends \lang\Object implements \Iterator {

--- a/src/main/php/util/data/Mapper.class.php
+++ b/src/main/php/util/data/Mapper.class.php
@@ -4,6 +4,7 @@
  * A mapper reaches applies a given mapper function to each value an
  * iterator returns and returns its result.
  *
+ * @deprecated
  * @test  xp://util.data.unittest.MapperTest
  */
 class Mapper extends AbstractMapper {

--- a/src/main/php/util/data/MapperWithKey.class.php
+++ b/src/main/php/util/data/MapperWithKey.class.php
@@ -3,6 +3,8 @@
 /**
  * A mapper reaches applies a given mapper function to each value an
  * iterator returns and returns its result.
+ *
+ * @deprecated
  */
 class MapperWithKey extends AbstractMapper {
 

--- a/src/main/php/util/data/Window.class.php
+++ b/src/main/php/util/data/Window.class.php
@@ -5,6 +5,7 @@
  * iterator that match its "skip" closure, then returns elements
  * until its "stop" closure is reached.
  *
+ * @deprecated
  * @see   php://LimitIterator but uses closures and not just offsets
  * @test  xp://util.data.unittest.WindowTest
  */

--- a/src/main/php/util/data/WindowWithKey.class.php
+++ b/src/main/php/util/data/WindowWithKey.class.php
@@ -4,6 +4,8 @@
  * A window is an iterator that skips elements from an underlying
  * iterator that match its "skip" closure, then returns elements
  * until its "stop" closure is reached.
+ *
+ * @deprecated
  */
 class WindowWithKey extends AbstractWindow {
 

--- a/src/test/php/util/data/unittest/FilterableTest.class.php
+++ b/src/test/php/util/data/unittest/FilterableTest.class.php
@@ -2,6 +2,7 @@
 
 use util\data\Filterable;
 
+/** @deprecated */
 class FilterableTest extends \unittest\TestCase {
 
   /**

--- a/src/test/php/util/data/unittest/FlattenerTest.class.php
+++ b/src/test/php/util/data/unittest/FlattenerTest.class.php
@@ -3,6 +3,7 @@
 use util\data\Flattener;
 use util\data\Sequence;
 
+/** @deprecated */
 class FlattenerTest extends \unittest\TestCase {
 
   /**

--- a/src/test/php/util/data/unittest/MapperTest.class.php
+++ b/src/test/php/util/data/unittest/MapperTest.class.php
@@ -3,6 +3,7 @@
 use util\data\Mapper;
 use lang\IllegalStateException;
 
+/** @deprecated */
 class MapperTest extends \unittest\TestCase {
 
   /**

--- a/src/test/php/util/data/unittest/WindowTest.class.php
+++ b/src/test/php/util/data/unittest/WindowTest.class.php
@@ -2,6 +2,7 @@
 
 use util\data\Window;
 
+/** @deprecated */
 class WindowTest extends \unittest\TestCase {
   protected static $fixture= [1, 2, 3, 4, 5];
 


### PR DESCRIPTION
## Performance comparison

Uses the class from [this gist](https://gist.github.com/thekid/825bbb7bf142476d614022176755ee1d)

```bash
# Before
$ xp -m ..\measure util.profiling.Measure Operations -n 1000
filter: 1000 iteration(s), 5.998 seconds, result= 5000
map: 1000 iteration(s), 7.635 seconds, result= 10000
peek: 1000 iteration(s), 8.342 seconds, result= 10000
flatten: 1000 iteration(s), 27.544 seconds, result= 20000
skip_n: 1000 iteration(s), 1.934 seconds, result= 9000
skip: 1000 iteration(s), 7.600 seconds, result= 9000
limit_n: 1000 iteration(s), 1.874 seconds, result= 9000
limit: 1000 iteration(s), 6.867 seconds, result= 9000

# After
$ xp -m ..\measure util.profiling.Measure Operations -n 1000
filter: 1000 iteration(s), 1.443 seconds, result= 5000
map: 1000 iteration(s), 1.558 seconds, result= 10000
peek: 1000 iteration(s), 1.317 seconds, result= 10000
flatten: 1000 iteration(s), 3.571 seconds, result= 20000
skip_n: 1000 iteration(s), 0.928 seconds, result= 9000
skip: 1000 iteration(s), 0.872 seconds, result= 9000
limit_n: 1000 iteration(s), 0.898 seconds, result= 9000
limit: 1000 iteration(s), 1.323 seconds, result= 9000
```

## Functions and their speedup

* [x] filter() - factor 4.1
* [x] map() - factor 4.9
* [x] peek() - factor 6.3
* [x] flatten() - factor 7.7
* [x] skip() - factor 2 (integer), factor 8.7 (function)
* [x] limit() - factor 2 (integer), factor 5.1 (function)
