### PR TITLE
Inline Generator class

### DIFF
--- a/src/main/php/util/data/Generator.class.php
+++ b/src/main/php/util/data/Generator.class.php
@@ -4,6 +4,7 @@
  * A generator produces an infinite sequence of data, like for example
  * `/dev/urandom` on Unix-like operating systems.
  *
+ * @deprecated
  * @test  xp://util.data.unittest.GeneratorTest
  */
 class Generator extends \lang\Object implements \Iterator {

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -78,12 +78,13 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @return self
    */
   public static function iterate($seed, $op) {
-    $value= $seed;
     $closure= Functions::$UNARYOP->newInstance($op);
-    return new self(new Generator(
-      function() use($value) { return $value; },
-      function() use(&$value, $closure) { $value= $closure($value); return $value; }
-    ));
+    $f= function() use($seed, $closure) {
+      yield $seed;
+      while (true) { yield $seed= $closure($seed); }
+    };
+
+    return new self($f());
   }
 
   /**
@@ -94,7 +95,11 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    */
   public static function generate($supplier) {
     $closure= Functions::$SUPPLY->newInstance($supplier);
-    return new self(new Generator($closure, $closure));
+    $f= function() use($closure) {
+      while (true) { yield $closure(); }
+    };
+
+    return new self($f());
   }
 
   /**

--- a/src/test/php/util/data/unittest/GeneratorTest.class.php
+++ b/src/test/php/util/data/unittest/GeneratorTest.class.php
@@ -2,6 +2,7 @@
 
 use util\data\Generator;
 
+/** @deprecated */
 class GeneratorTest extends \unittest\TestCase {
 
   /**


### PR DESCRIPTION
(*Like #39 but for `generate()` and `iterate()` creation methods)*

Measurable:

```php
use util\data\Sequence;

class Operations extends \util\profiling\Measurable {

  #[@measure]
  public function generate() {
    return Sequence::generate('rand')
      ->limit(10000)
      ->each()
    ;
  }

  #[@measure]
  public function iterate() {
    return Sequence::iterate(0, function($i) { return $i+= 2; })
      ->limit(10000)
      ->each()
    ;
  }
}
```

Results:

```bash
# Before
$ xp -m ..\measure util.profiling.Measure Operations -n 1000
generate: 1000 iteration(s), 5.367 seconds, result= 10000
iterate: 1000 iteration(s), 6.571 seconds, result= 10000

# After
$ xp -m ..\measure util.profiling.Measure Operations -n 1000
generate: 1000 iteration(s), 1.908 seconds, result= 10000
iterate: 1000 iteration(s), 2.243 seconds, result= 10000
```

The speedup is between 2.8 and 2.9 for both methods