### PR TITLE
Deprecate static concat() in favor of multiple-argument of() 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Sequences can be created from a variety of sources, and by using these static me
 * **of** - accepts PHP arrays (zero-based as well as associative), all traversable data structures including `lang.types.ArrayList` and `lang.types.ArrayMap` as well as anything from `util.collections`, `util.XPIterator` instances, PHP iterators and iterator aggregates, PHP 5.5 generators (*yield*), as well as sequences themselves. Passing NULL will yield an empty sequence.
 * **iterate** - Iterates starting with a given seed, applying a unary operator on this value and passing the result to the next invocation, forever. Combine with `limit()`!
 * **generate** - Iterates forever, returning whatever the given supplier function returns. Combine with `limit()`!
-* **concat** - Concatenates a variable number of arguments with anything `of()` accepts into one large sequence.
 
 Intermediate operations
 -----------------------

--- a/src/main/php/util/data/Enumeration.class.php
+++ b/src/main/php/util/data/Enumeration.class.php
@@ -41,6 +41,8 @@ abstract class Enumeration extends \lang\Object {
       }
     } else if ($arg instanceof XPIterator) {
       return new XPIteratorAdapter($arg);
+    } else if (null === $arg) {
+      return [];
     } else if (is_array($arg)) {
       return $arg;
     }

--- a/src/main/php/util/data/Enumeration.class.php
+++ b/src/main/php/util/data/Enumeration.class.php
@@ -24,7 +24,7 @@ abstract class Enumeration extends \lang\Object {
    * Verifies a given argument is an enumeration
    *
    * @param  var $arg
-   * @return var
+   * @return iterable
    * @throws lang.IllegalArgumentException
    */
   public static function of($arg) {

--- a/src/main/php/util/data/Iterators.class.php
+++ b/src/main/php/util/data/Iterators.class.php
@@ -6,6 +6,7 @@ use util\XPIterator;
 /**
  * Represents a list of iterators
  *
+ * @deprecated Use Sequence::of() instead of Sequence::concat()
  * @see   php://AppendIterator
  * @test  xp://util.data.unittest.SequenceResultSetTest
  */

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -40,13 +40,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /** @return util.XPIterator */
   public function iterator() { return new SequenceIterator($this); }
 
-  /**
-   * Gets an iterator on this stream. Optimizes the case that the underlying
-   * elements already is an Iterator, and handles both wrappers implementing
-   * the Traversable interfaces as well as primitive arrays.
-   *
-   * @return  php.Iterator
-   */
+  /** @return iterable */
   public function getIterator() {
     foreach ($this->elements as $key => $element) {
       yield $key => $element;
@@ -88,8 +82,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   public static function iterate($seed, $op) {
     $closure= Functions::$UNARYOP->newInstance($op);
     $f= function() use($seed, $closure) {
-      yield $seed;
-      while (true) { yield $seed= $closure($seed); }
+      while (true) { yield $seed; $seed= $closure($seed); }
     };
 
     return new self($f());

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -57,16 +57,25 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * Creates a new stream with an enumeration of elements
    *
    * @see    xp://util.data.Enumeration
-   * @param  var $elements an iterator, iterable, generator or array
+   * @param  var... $enumerables an iterator, iterable, generator or array
    * @return self
    * @throws lang.IllegalArgumentException if type of elements argument is incorrect
    */
-  public static function of($elements) {
-    if (null === $elements) {
-      return self::$EMPTY;
-    } else {
-      return new self(Enumeration::of($elements));
+  public static function of(... $enumerables) {
+
+    // Short-circuit this use-case for performance / memory reasons
+    if (1 === sizeof($enumerables)) {
+      return new self(Enumeration::of($enumerables[0]));
     }
+
+    $f= function() use($enumerables) {
+      foreach ($enumerables as $arg) {
+        foreach (Enumeration::of($arg) as $key => $element) {
+          yield $key => $element;
+        }
+      }
+    };
+    return new self($f());
   }
 
   /**

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -114,6 +114,7 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   /**
    * Concatenates all given iteration sources
    *
+   * @deprecated Use Sequence::of() instead of Sequence::concat()
    * @param  var... $args An iterator, iterable or an array
    * @return self
    */

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -62,20 +62,19 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
    * @throws lang.IllegalArgumentException if type of elements argument is incorrect
    */
   public static function of(... $enumerables) {
-
-    // Short-circuit this use-case for performance / memory reasons
-    if (1 === sizeof($enumerables)) {
-      return new self(Enumeration::of($enumerables[0]));
+    switch (sizeof($enumerables)) {
+      case 1: return new self(Enumeration::of($enumerables[0]));
+      case 0: throw new IllegalArgumentException('Expecting at least one argument');
+      default:
+        $f= function() use($enumerables) {
+          foreach ($enumerables as $arg) {
+            foreach (Enumeration::of($arg) as $key => $element) {
+              yield $key => $element;
+            }
+          }
+        };
+        return new self($f());
     }
-
-    $f= function() use($enumerables) {
-      foreach ($enumerables as $arg) {
-        foreach (Enumeration::of($arg) as $key => $element) {
-          yield $key => $element;
-        }
-      }
-    };
-    return new self($f());
   }
 
   /**

--- a/src/test/php/util/data/unittest/EnumerationTest.class.php
+++ b/src/test/php/util/data/unittest/EnumerationTest.class.php
@@ -28,8 +28,13 @@ class EnumerationTest extends \unittest\TestCase {
     Enumeration::of($value);
   }
 
+  #[@test]
+  public function returns_empty_enumerable_for_null() {
+    $this->assertEquals([], Enumeration::of(null));
+  }
+
   #[@test, @expect(IllegalArgumentException::class)]
-  public function raises_exception_when_given_null() {
-    Enumeration::of(null);
+  public function returns_empty_enumerable_for_non_iterables() {
+    Enumeration::of('a string');
   }
 }

--- a/src/test/php/util/data/unittest/EnumerationTest.class.php
+++ b/src/test/php/util/data/unittest/EnumerationTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace util\data\unittest;
 
 use util\data\Enumeration;
+use util\data\Sequence;
 use lang\IllegalArgumentException;
 
 class EnumerationTest extends \unittest\TestCase {
@@ -21,6 +22,15 @@ class EnumerationTest extends \unittest\TestCase {
       $result[$key]= $value;
     }
     $this->assertEquals(['color' => 'green', 'price' => 12.99], $result, $desc);
+  }
+
+  #[@test]
+  public function all_in_sequence() {
+    $result= [];
+    foreach (Enumeration::of(Sequence::of([1, 2, 3])) as $value) {
+      $result[]= $value;
+    }
+    $this->assertEquals([1, 2, 3], $result);
   }
 
   #[@test, @values('util.data.unittest.Enumerables::invalid'), @expect(IllegalArgumentException::class)]

--- a/src/test/php/util/data/unittest/SequenceConcatTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceConcatTest.class.php
@@ -2,6 +2,7 @@
 
 use util\data\Sequence;
 
+/** @deprecated Use Sequence::of() instead of Sequence::concat() */
 class SequenceConcatTest extends AbstractSequenceTest {
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -45,4 +45,14 @@ class SequenceCreationTest extends AbstractSequenceTest {
   public function passing_null_to_of_yields_an_empty_sequence() {
     $this->assertEquals(Sequence::$EMPTY, Sequence::of(null));
   }
+
+  #[@test, @values([
+  #  [[1, 2, 3, 4, 5, 6]],
+  #  [[1, 2, 3], [4, 5, 6]],
+  #  [[1], [2, 3], [4, 5, 6]],
+  #  [[1, 2], null, [3, 4, 5, 6]]
+  #])]
+  public function multiple_arguments_supported_in_of(... $input) {
+    $this->assertSequence([1, 2, 3, 4, 5, 6], Sequence::of(...$input));
+  }
 }

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -11,6 +11,11 @@ use lang\IllegalArgumentException;
  */
 class SequenceCreationTest extends AbstractSequenceTest {
 
+  #[@test, @expect(IllegalArgumentException::class)]
+  public function missing_argument() {
+    Sequence::of();
+  }
+
   #[@test, @values('util.data.unittest.Enumerables::valid')]
   public function can_create_via_of($input, $name) {
     $this->assertInstanceOf(Sequence::class, Sequence::of($input), $name);

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -51,6 +51,13 @@ class SequenceCreationTest extends AbstractSequenceTest {
     $this->assertEquals(Sequence::$EMPTY, Sequence::of(null));
   }
 
+  #[@test]
+  public function passing_sequence_to_of_yields_itself() {
+    $sequence= Sequence::of([1, 2, 3]);
+    $this->assertSequence([1, 2, 3], Sequence::of($sequence));
+  }
+
+
   #[@test, @values([
   #  [[1, 2, 3, 4, 5, 6]],
   #  [[1, 2, 3], [4, 5, 6]],


### PR DESCRIPTION
Like #38 but also deprecates the `Iterators` class.

## Example

```php
// Before
$s= Sequence::concat(Sequence::of([$topOrgUnit]), Sequence::of($childOrgUnits));

// Refactoring is easy: Simply replace concat() with of()
$s= Sequence::of(Sequence::of([$topOrgUnit]), Sequence::of($childOrgUnits));

// Optional next step: Remove Sequence::of() around arguments:
$s= Sequence::of([$topOrgUnit], $childOrgUnits);
```
