### PR TITLE
XP9 Compat

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,10 @@ Data sequences change log
 
 ## ?.?.? / ????-??-??
 
+## 8.0.0 / 2017-05-28
+
+* Merged PR #45: Forward compatibility with XP 9.0.0 - @thekid
+
 ## 7.0.1 / 2017-05-20
 
 * Refactored code to use dedicated fixture methods instead of using

--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
   "description" : "Data sequences",
   "keywords": ["module", "xp"],
   "require" : {
-    "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
+    "xp-framework/core": "^9.0 | ^8.0 | ^7.0 | ^6.5",
     "xp-framework/collections": "^8.0 | ^7.0 | ^6.5",
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^7.0 | ^6.5"
+    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/main/php/util/data/Collector.class.php
+++ b/src/main/php/util/data/Collector.class.php
@@ -6,7 +6,7 @@
  * @see   xp://util.data.Sequence#collect
  * @test  xp://util.data.unittest.CollectorsTest
  */
-class Collector extends \lang\Object implements ICollector {
+class Collector implements ICollector {
   protected $supplier;
   protected $accumulator;
   protected $finisher;

--- a/src/main/php/util/data/Collectors.class.php
+++ b/src/main/php/util/data/Collectors.class.php
@@ -11,7 +11,7 @@ use util\collections\HashSet;
  * @see   xp://util.data.ICollector
  * @test  xp://util.data.unittest.CollectorsTest
  */
-final class Collectors extends \lang\Object {
+final class Collectors {
 
   private function __construct() { }
 

--- a/src/main/php/util/data/Enumeration.class.php
+++ b/src/main/php/util/data/Enumeration.class.php
@@ -18,7 +18,7 @@ use lang\IllegalArgumentException;
  * @see   xp://util.XPIterator
  * @test  xp://util.data.unittest.EnumerationTest
  */
-abstract class Enumeration extends \lang\Object {
+abstract class Enumeration {
 
   /**
    * Verifies a given argument is an enumeration

--- a/src/main/php/util/data/Functions.class.php
+++ b/src/main/php/util/data/Functions.class.php
@@ -7,7 +7,7 @@ use lang\Primitive;
 /**
  * Function types used throughout library
  */
-abstract class Functions extends \lang\Object {
+abstract class Functions {
   public static $SUPPLY, $CONSUME, $CONSUME_WITH_KEY, $UNARYOP, $BINARYOP, $COMPARATOR, $APPLY, $APPLY_WITH_KEY;
 
   static function __static() {

--- a/src/main/php/util/data/Optional.class.php
+++ b/src/main/php/util/data/Optional.class.php
@@ -9,7 +9,7 @@ use util\Objects;
  *
  * @test  xp://util.data.unittest.OptionalTest
  */
-class Optional extends \lang\Object implements \IteratorAggregate {
+class Optional implements \lang\Value, \IteratorAggregate {
   public static $EMPTY;
 
   protected $value;
@@ -142,13 +142,16 @@ class Optional extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
-   * Returns whether this optional equals a given value.
+   * Compares this optional to another given value
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->present === $cmp->present && Objects::equal($this->value, $cmp->value);
+  public function compareTo($value) {
+    return $value instanceof self
+      ? Objects::compare([$this->present, $this->value], [$value->present, $value->value])
+      : 1
+    ;
   }
 
   /**

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -23,7 +23,7 @@ use lang\Throwable;
  * @test xp://util.data.unittest.SequenceResultSetTest
  * @test xp://util.data.unittest.SequenceSkipTest
  */
-class Sequence extends \lang\Object implements \IteratorAggregate {
+class Sequence implements \lang\Value, \IteratorAggregate {
   public static $EMPTY;
 
   protected $elements;
@@ -589,13 +589,13 @@ class Sequence extends \lang\Object implements \IteratorAggregate {
   }
 
   /**
-   * Returns whether this sequence equals a given value.
+   * Compares this optional to another given value
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $value
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && Objects::equal($this->elements, $cmp->elements);
+  public function compareTo($value) {
+    return $value instanceof self ? Objects::compare($this->elements, $value->elements) : 1;
   }
 
   /**

--- a/src/main/php/util/data/SequenceIterator.class.php
+++ b/src/main/php/util/data/SequenceIterator.class.php
@@ -8,7 +8,7 @@ use util\NoSuchElementException;
  * @see  xp://util.data.Sequence#iterator
  * @test xp://util.data.unittest.SequenceIteratorTest
  */
-class SequenceIterator extends \lang\Object implements \util\XPIterator, \IteratorAggregate {
+class SequenceIterator implements \util\XPIterator, \IteratorAggregate {
   private $it;
 
   /**

--- a/src/main/php/util/data/XPIteratorAdapter.class.php
+++ b/src/main/php/util/data/XPIteratorAdapter.class.php
@@ -4,7 +4,7 @@
  * Adapter class for wrapping an util.XPIterator instance in an iterator
  * useable by PHP.
  */
-class XPIteratorAdapter extends \lang\Object implements \Iterator {
+class XPIteratorAdapter implements \Iterator {
   private $it;
   private $key= -1, $current= null, $valid= false;
 

--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -71,7 +71,7 @@ abstract class AbstractSequenceTest extends \unittest\TestCase {
   protected function noncallables() {
     return [
       [null], [''], ['...'], [-1], [0], [1], [0.5], [false], [true],
-      [new Object()], [new Name('...')], [$this],
+      [new Name('...')], [$this],
       [[]], [[$this]], [['xp']], [['xp', 'g']], [[$this, 'getName', 'excess-element']],
       ['xp:g'], ['xp::'], ['xp::g'], ['::gc'], ['typeo']
     ];

--- a/src/test/php/util/data/unittest/Employee.class.php
+++ b/src/test/php/util/data/unittest/Employee.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-class Employee extends \lang\Object {
+class Employee implements \lang\Value {
   protected $id;
   protected $name;
   protected $department;
@@ -36,24 +36,25 @@ class Employee extends \lang\Object {
   /** @return bool */
   public function isDinosaur() { return $this->years > 10; }
 
-  /**
-   * Creates a string representation
-   *
-   * @return string
-   */
+  /** Creates a string representation */
   public function toString() {
     return nameof($this).'('.
       'id= '.$this->id.', name= '.$this->name.', department= '.$this->department.', years= '.$this->years.
     ')';
   }
 
+  /** Creates a hashcode */
+  public function hashCode() {
+    return 'E'.$this->id;
+  }
+
   /**
    * Compares this employee to another given value
    *
-   * @param  var $cmp
-   * @return bool
+   * @param  var $valu
+   * @return int
    */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->id === $cmp->id;
+  public function compareTo($value) {
+    return $value instanceof self ? $this->id - $value->id : 1;
   }
 }

--- a/src/test/php/util/data/unittest/Enumerables.class.php
+++ b/src/test/php/util/data/unittest/Enumerables.class.php
@@ -1,7 +1,6 @@
 <?php namespace util\data\unittest;
 
 use util\XPIterator;
-use lang\Object;
 use util\data\Sequence;
 
 /**
@@ -14,7 +13,7 @@ use util\data\Sequence;
  * @see   xp://util.data.unittest.AbstractSequenceTest
  * @see   php://generators
  */
-abstract class Enumerables extends Object {
+abstract class Enumerables {
 
   /**
    * Returns valid arguments for the `of()` method.
@@ -114,7 +113,7 @@ abstract class Enumerables extends Object {
   public static function invalid() {
     return [
       [''], ['...'], [-1], [0], [1], [0.5], [false], [true],
-      [new Object()], [new Name('...')],
+      [new Name('...')],
       [function() { return 1; }]
     ];
   }

--- a/src/test/php/util/data/unittest/Name.class.php
+++ b/src/test/php/util/data/unittest/Name.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-class Name extends \lang\Object {
+class Name implements \lang\Value {
   private $value;
 
   /** @param string $value */
@@ -10,30 +10,26 @@ class Name extends \lang\Object {
   public function value() { return $this->value; }
 
   /**
-   * Returns a hashcode
-   *
-   * @return string
-   */
-  public function hashCode() {
-    return crc32($this->value);
-  }
-
-  /**
-   * Returns whether this name is equal to another
-   *
-   * @param  var $cmp
-   * @return bool
-   */
-  public function equals($cmp) {
-    return $cmp instanceof self && $this->value === $cmp->value;
-  }
-
-  /**
    * Returns a string representation
    *
    * @return string
    */
   public function toString() {
     return nameof($this).'('.$this->value.')';
+  }
+
+  /** Creates a string representatio */
+  public function hashCode() {
+    return crc32($this->value);
+  }
+
+  /**
+   * Compares this employee to another given value
+   *
+   * @param  var $valu
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? strcmp($this->value, $value->value) : 1;
   }
 }

--- a/src/test/php/util/data/unittest/Person.class.php
+++ b/src/test/php/util/data/unittest/Person.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-class Person extends \lang\Object {
+class Person implements \lang\Value {
   private $id, $name;
 
   /**
@@ -19,4 +19,24 @@ class Person extends \lang\Object {
 
   /** @return string */
   public function name() { return $this->name; }
+
+  /** Creates a string representation */
+  public function toString() {
+    return nameof($this).'(id= '.$this->id.', name= '.$this->name.')';
+  }
+
+  /** Creates a hashcode */
+  public function hashCode() {
+    return 'P'.$this->id;
+  }
+
+  /**
+   * Compares this employee to another given value
+   *
+   * @param  var $valu
+   * @return int
+   */
+  public function compareTo($value) {
+    return $value instanceof self ? $this->id - $value->id : 1;
+  }
 }


### PR DESCRIPTION
This pull request makes the unittest library compatible with XP9:

* Removes `lang.Object` references, replacing them with dedicated value objects
* Implements `lang.Value` where toString() / hashCode() / comparison are necessary
* Adds `^9.0` to composer.json

See also https://github.com/orgs/xp-framework/projects/1