### PR TITLE
Fluent interface to catch exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ language: php
 dist: trusty
 
 php:
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
   - nightly
 
 matrix:

--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -1,6 +1,5 @@
 <?php namespace util\data\unittest;
 
-use lang\Object;
 use util\data\Sequence;
 use util\data\Collector;
 

--- a/src/test/php/util/data/unittest/CatchTest.class.php
+++ b/src/test/php/util/data/unittest/CatchTest.class.php
@@ -1,0 +1,50 @@
+<?php namespace util\data\unittest;
+
+use util\data\Sequence;
+use lang\IllegalStateException;
+
+class CatchTest extends \unittest\TestCase {
+
+  #[@test, @expect(IllegalStateException::class)]
+  public function without_catch() {
+    $fixture= Sequence::of([1, 2, 3])
+      ->peek(function($i) { if (0 === $i % 2) throw new IllegalStateException('Only odd numbers expected'); })
+    ;
+    $fixture->toArray();
+  }
+
+  #[@test]
+  public function catch_nothing() {
+    $fixture= Sequence::of([1, 2, 3])
+      ->catch(function($e) { throw new IllegalStateException('Should not be reached'); })
+    ;
+    $this->assertEquals([1, 2, 3], $fixture->toArray());
+  }
+
+  #[@test]
+  public function catch_exception_from_peek() {
+    $fixture= Sequence::of([1, 2, 3])
+      ->peek(function($i) { if (0 === $i % 2) throw new IllegalStateException('Only odd numbers expected'); })
+      ->catch(function($e) { yield -1; })
+    ;
+    $this->assertEquals([1, -1, 3], $fixture->toArray());
+  }
+
+  #[@test]
+  public function catch_exception_from_map() {
+    $fixture= Sequence::of([1, 2, 3])
+      ->map(function($i) { if (0 === $i % 2) throw new IllegalStateException('Only odd numbers expected'); return $i; })
+      ->catch(function($e) { yield -1; })
+    ;
+    $this->assertEquals([1, -1, 3], $fixture->toArray());
+  }
+
+  #[@test]
+  public function catch_exception_from_filter() {
+    $fixture= Sequence::of([1, 2, 3])
+      ->filter(function($i) { if (0 === $i % 2) throw new IllegalStateException('Only odd numbers expected'); return true; })
+      ->catch(function($e) { yield -1; })
+    ;
+    $this->assertEquals([1, -1, 3], $fixture->toArray());
+  }
+}

--- a/src/test/php/util/data/unittest/PeekTest.class.php
+++ b/src/test/php/util/data/unittest/PeekTest.class.php
@@ -10,7 +10,7 @@ class PeekTest extends AbstractSequenceTest {
 
   #[@test, @expect(IllegalArgumentException::class), @values(['@non-existant-func@'])]
   public function invalid($arg) {
-    Sequence::$EMPTY->peek($arg);
+    Sequence::empty()->peek($arg);
   }
 
   #[@test]

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -48,7 +48,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test]
   public function passing_null_to_of_yields_an_empty_sequence() {
-    $this->assertEquals(Sequence::$EMPTY, Sequence::of(null));
+    $this->assertEquals(Sequence::empty(), Sequence::of(null));
   }
 
   #[@test]

--- a/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
@@ -33,12 +33,12 @@ class SequenceIteratorTest extends AbstractSequenceTest {
 
   #[@test]
   public function hasNext_returns_false_when_at_end_of_sequence() {
-    $this->assertFalse(Sequence::$EMPTY->iterator()->hasNext());
+    $this->assertFalse(Sequence::empty()->iterator()->hasNext());
   }
 
   #[@test, @expect(NoSuchElementException::class)]
   public function next_throws_exception_when_at_end_of_sequence() {
-    Sequence::$EMPTY->iterator()->next();
+    Sequence::empty()->iterator()->next();
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -28,12 +28,12 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function empty_sequence() {
-    $this->assertSequence([], Sequence::$EMPTY);
+    $this->assertSequence([], Sequence::empty());
   }
 
   #[@test]
   public function toArray_for_empty_sequence() {
-    $this->assertEquals([], Sequence::$EMPTY->toArray());
+    $this->assertEquals([], Sequence::empty()->toArray());
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
@@ -51,7 +51,7 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function toMap_for_empty_sequence() {
-    $this->assertEquals([], Sequence::$EMPTY->toMap());
+    $this->assertEquals([], Sequence::empty()->toMap());
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validMaps')]
@@ -186,7 +186,7 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function toString_for_empty_sequence() {
-    $this->assertEquals('util.data.Sequence<EMPTY>', Sequence::$EMPTY->toString());
+    $this->assertEquals('util.data.Sequence<EMPTY>', Sequence::empty()->toString());
   }
 
   #[@test]


### PR DESCRIPTION
## Example

```php
Sequence::of($import)
  ->peek(function($record) { Console::write($record['name']); })
  ->map(function($record) {
    $existing= $this->database->lookup($record['name']);
    return $this->database->replace($existing, $record);
  })
  ->catch(function($e) { $e->printStackTrace(); })
  ->peek(function($id) { Console::writeLine(' -> #', $id); )
  ->each()
;
```

## BC break

⚠️ `Sequence::$EMPTY` needs to b rewritten as `Sequence::empty()`.

## Performance

This pull request introduces wide-ranging implementation changes, which also have a slight performance hit:

```bash
# [feature/catch]
$ xp -m ../measure/ measure -n 1000 Operations
counting: 1000 iteration(s), 1.159 seconds, result= 10000
collecting: 1000 iteration(s), 2.067 seconds, result= 10000

# [master]
$ xp -m ../measure/ measure -n 1000 Operations
counting: 1000 iteration(s), 1.013 seconds, result= 10000
collecting: 1000 iteration(s), 1.857 seconds, result= 10000
```

See also http://reactivex.io/documentation/operators/catch.html and #30 