### PR TITLE
Convert testsuite to baseless

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "dev-feature/baseless-single-instance as 10.0.0"
+    "xp-framework/unittest": "^10.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=5.6.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^9.0 | ^8.0 | ^7.0 | ^6.5"
+    "xp-framework/unittest": "dev-feature/baseless-single-instance as 10.0.0"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
+use unittest\Assert;
 use util\data\Collector;
+use util\data\Sequence;
 
-abstract class AbstractSequenceTest extends \unittest\TestCase {
+abstract class AbstractSequenceTest {
 
   /**
    * Assertion helper
@@ -14,7 +15,7 @@ abstract class AbstractSequenceTest extends \unittest\TestCase {
    * @throws unittest.AssertionFailedError
    */
   protected function assertSequence($expected, $sequence, $message= '!=') {
-    $this->assertEquals($expected, $sequence->toArray(), $message);
+    Assert::equals($expected, $sequence->toArray(), $message);
   }
 
   /**

--- a/src/test/php/util/data/unittest/AggregationsTest.class.php
+++ b/src/test/php/util/data/unittest/AggregationsTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\data\Aggregations;
 use util\data\Sequence;
 
-class AggregationsTest extends \unittest\TestCase {
+class AggregationsTest {
 
   #[@test]
   public function min_max_sum_average_and_count_for_empty_sequence() {
@@ -15,11 +16,11 @@ class AggregationsTest extends \unittest\TestCase {
       ->collecting($count, Aggregations::count())
       ->each()
     ;
-    $this->assertNull($min);
-    $this->assertNull($max);
-    $this->assertNull($average);
-    $this->assertNull($sum);
-    $this->assertEquals(0, $count);
+    Assert::null($min);
+    Assert::null($max);
+    Assert::null($average);
+    Assert::null($sum);
+    Assert::equals(0, $count);
   }
 
   #[@test]
@@ -32,10 +33,10 @@ class AggregationsTest extends \unittest\TestCase {
       ->collecting($count, Aggregations::count())
       ->each()
     ;
-    $this->assertEquals(1, $min);
-    $this->assertEquals(4, $max);
-    $this->assertEquals(2.5, $average);
-    $this->assertEquals(10, $sum);
-    $this->assertEquals(4, $count);
+    Assert::equals(1, $min);
+    Assert::equals(4, $max);
+    Assert::equals(2.5, $average);
+    Assert::equals(10, $sum);
+    Assert::equals(4, $count);
   }
 }

--- a/src/test/php/util/data/unittest/BoundariesTest.class.php
+++ b/src/test/php/util/data/unittest/BoundariesTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\Comparator;
-use util\data\Sequence;
 use util\Date;
+use util\data\Sequence;
 
 class BoundariesTest extends AbstractSequenceTest {
 
@@ -12,12 +13,12 @@ class BoundariesTest extends AbstractSequenceTest {
   #  [2, [10, 7, 2]]
   #])]
   public function min($result, $values) {
-    $this->assertEquals($result, Sequence::of($values)->min());
+    Assert::equals($result, Sequence::of($values)->min());
   }
 
   #[@test]
   public function min_using_comparator() {
-    $this->assertEquals(
+    Assert::equals(
       new Date('1977-12-14'),
       Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->min(newinstance(Comparator::class, [], [
         'compare' => function($a, $b) { return $b->compareTo($a); }
@@ -27,7 +28,7 @@ class BoundariesTest extends AbstractSequenceTest {
 
   #[@test]
   public function min_using_closure() {
-    $this->assertEquals(
+    Assert::equals(
       new Date('1977-12-14'),
       Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->min(function($a, $b) {
         return $b->compareTo($a);
@@ -41,12 +42,12 @@ class BoundariesTest extends AbstractSequenceTest {
   #  [10, [2, 10, 7]]
   #])]
   public function max($result, $values) {
-    $this->assertEquals($result, Sequence::of($values)->max());
+    Assert::equals($result, Sequence::of($values)->max());
   }
 
   #[@test]
   public function max_using_comparator() {
-    $this->assertEquals(
+    Assert::equals(
       new Date('2014-07-17'),
       Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->max(newinstance(Comparator::class, [], [
         'compare' => function($a, $b) { return $b->compareTo($a); }
@@ -56,7 +57,7 @@ class BoundariesTest extends AbstractSequenceTest {
 
   #[@test]
   public function max_using_closure() {
-    $this->assertEquals(
+    Assert::equals(
       new Date('2014-07-17'),
       Sequence::of([new Date('1977-12-14'), new Date('2014-07-17'), new Date('1979-12-29')])->max(function($a, $b) {
         return $b->compareTo($a);

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -1,6 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\XPClass;
+use unittest\Assert;
 use util\collections\HashSet;
 use util\collections\HashTable;
 use util\collections\Vector;
@@ -8,12 +9,13 @@ use util\data\Collector;
 use util\data\Collectors;
 use util\data\Sequence;
 
-class CollectorsTest extends \unittest\TestCase {
+class CollectorsTest {
   private $people;
 
   /**
    * Sets up test, initializing people member
    */
+  #[@before]
   public function setUp() {
     $this->people= [
       1549 => new Employee(1549, 'Timm', 'B', 15),
@@ -30,12 +32,12 @@ class CollectorsTest extends \unittest\TestCase {
    * @throws unittest.AssertionFailedError
    */
   private function assertHashTable($expected, $actual) {
-    $this->assertInstanceOf(HashTable::class, $actual);
+    Assert::instance(HashTable::class, $actual);
     $compare= [];
     foreach ($actual as $pair) {
       $compare[$pair->key]= $pair->value;
     }
-    return $this->assertEquals($expected, $compare);
+    return Assert::equals($expected, $compare);
   }
 
   /** @return var[][] */
@@ -72,7 +74,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test, @values('employeesName')]
   public function toList($nameOf) {
-    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+    Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map($nameOf)
       ->collect(Collectors::toList())
       ->elements()
@@ -81,7 +83,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test, @values('employeesName')]
   public function toList_with_extraction($nameOf) {
-    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+    Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->collect(Collectors::toList($nameOf))
       ->elements()
     );
@@ -89,7 +91,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test, @values('employeesName')]
   public function toSet($nameOf) {
-    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+    Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map($nameOf)
       ->collect(Collectors::toSet())
       ->toArray()
@@ -98,7 +100,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test, @values('employeesName')]
   public function toSet_with_extraction($nameOf) {
-    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+    Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->collect(Collectors::toSet($nameOf))
       ->toArray()
     );
@@ -106,7 +108,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test, @values('employeesName')]
   public function toCollection_with_HashSet_class($nameOf) {
-    $this->assertEquals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
+    Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map($nameOf)
       ->collect(Collectors::toCollection(XPClass::forName('util.collections.HashSet')))
       ->toArray()
@@ -120,7 +122,7 @@ class CollectorsTest extends \unittest\TestCase {
     $map[1552]= 'Alex';
     $map[6100]= 'Dude';
 
-    $this->assertEquals($map, Sequence::of($this->people)->collect(Collectors::toMap(
+    Assert::equals($map, Sequence::of($this->people)->collect(Collectors::toMap(
       function($e) { return $e->id(); },
       $nameOf
     )));
@@ -133,7 +135,7 @@ class CollectorsTest extends \unittest\TestCase {
     $map['Alex']= $this->people[1552];
     $map['Dude']= $this->people[6100];
 
-    $this->assertEquals($map, Sequence::of($this->people)->collect(Collectors::toMap(
+    Assert::equals($map, Sequence::of($this->people)->collect(Collectors::toMap(
       $nameOf,
       null
     )));
@@ -144,7 +146,7 @@ class CollectorsTest extends \unittest\TestCase {
     $map= new HashTable();
     $map['color']= 'green';
 
-    $this->assertEquals($map, Sequence::of(['color' => 'green'])->collect(Collectors::toMap()));
+    Assert::equals($map, Sequence::of(['color' => 'green'])->collect(Collectors::toMap()));
   }
 
   #[@test]
@@ -152,7 +154,7 @@ class CollectorsTest extends \unittest\TestCase {
     $map= new HashTable();
     $map['color']= 'GREEN';
 
-    $this->assertEquals($map, Sequence::of(['color' => 'green'])->collect(Collectors::toMap(
+    Assert::equals($map, Sequence::of(['color' => 'green'])->collect(Collectors::toMap(
       null,
       'strtoupper'
     )));
@@ -164,19 +166,19 @@ class CollectorsTest extends \unittest\TestCase {
       function() { return []; },
       function(&$result, $arg, $key) { $result[strtoupper($key)]= $arg; }
     ));
-    $this->assertEquals(['COLOR' => 'green', 'PRICE' => 12.99], $result);
+    Assert::equals(['COLOR' => 'green', 'PRICE' => 12.99], $result);
   }
 
   #[@test, @values('employeesYears')]
   public function summing_years($yearsOf) {
-    $this->assertEquals(33, Sequence::of($this->people)
+    Assert::equals(33, Sequence::of($this->people)
       ->collect(Collectors::summing($yearsOf))
     );
   }
 
   #[@test, @values('employeesYears')]
   public function summing_elements($yearsOf) {
-    $this->assertEquals(33, Sequence::of($this->people)
+    Assert::equals(33, Sequence::of($this->people)
       ->map($yearsOf)
       ->collect(Collectors::summing())
     );
@@ -184,14 +186,14 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test, @values('employeesYears')]
   public function averaging_years($yearsOf) {
-    $this->assertEquals(11, Sequence::of($this->people)
+    Assert::equals(11, Sequence::of($this->people)
       ->collect(Collectors::averaging($yearsOf))
     );
   }
 
   #[@test, @values('employeesYears')]
   public function averaging_elements($yearsOf) {
-    $this->assertEquals(11, Sequence::of($this->people)
+    Assert::equals(11, Sequence::of($this->people)
       ->map($yearsOf)
       ->collect(Collectors::averaging())
     );
@@ -199,21 +201,21 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test]
   public function counting() {
-    $this->assertEquals(3, Sequence::of($this->people)
+    Assert::equals(3, Sequence::of($this->people)
       ->collect(Collectors::counting())
     );
   }
 
   #[@test, @values('employeesDepartment')]
   public function mapping_by_department($departmentOf) {
-    $this->assertEquals(new Vector(['B', 'I', 'I']), Sequence::of($this->people)
+    Assert::equals(new Vector(['B', 'I', 'I']), Sequence::of($this->people)
       ->collect(Collectors::mapping($departmentOf))
     );
   }
 
   #[@test]
   public function joining_names() {
-    $this->assertEquals('Timm, Alex, Dude', Sequence::of($this->people)
+    Assert::equals('Timm, Alex, Dude', Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::joining())
     );
@@ -221,7 +223,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test]
   public function joining_names_with_semicolon() {
-    $this->assertEquals('Timm;Alex;Dude', Sequence::of($this->people)
+    Assert::equals('Timm;Alex;Dude', Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::joining(';'))
     );
@@ -229,7 +231,7 @@ class CollectorsTest extends \unittest\TestCase {
 
   #[@test]
   public function joining_names_with_prefix_and_suffix() {
-    $this->assertEquals('(Timm, Alex, Dude)', Sequence::of($this->people)
+    Assert::equals('(Timm, Alex, Dude)', Sequence::of($this->people)
       ->map(function($e) { return $e->name(); })
       ->collect(Collectors::joining(', ', '(', ')'))
     );
@@ -290,6 +292,6 @@ class CollectorsTest extends \unittest\TestCase {
       ))
       ->each()
     ;
-    $this->assertEquals(['B' => [1549], 'I' => [1552, 6100]], $result);
+    Assert::equals(['B' => [1549], 'I' => [1552, 6100]], $result);
   }
 }

--- a/src/test/php/util/data/unittest/ContinuationOfTest.class.php
+++ b/src/test/php/util/data/unittest/ContinuationOfTest.class.php
@@ -1,16 +1,17 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\data\ContinuationOf;
 use util\data\Sequence;
 
-class ContinuationOfTest extends \unittest\TestCase {
+class ContinuationOfTest {
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
   public function at_beginning($input) {
     $it= Sequence::of($input)->getIterator();
     $it->rewind();
 
-    $this->assertEquals([0 => 1, 1 => 2, 2 => 3], iterator_to_array(new ContinuationOf($it)));
+    Assert::equals([0 => 1, 1 => 2, 2 => 3], iterator_to_array(new ContinuationOf($it)));
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
@@ -19,7 +20,7 @@ class ContinuationOfTest extends \unittest\TestCase {
     $it->rewind();
     $it->next();
 
-    $this->assertEquals([1 => 2, 2 => 3], iterator_to_array(new ContinuationOf($it)));
+    Assert::equals([1 => 2, 2 => 3], iterator_to_array(new ContinuationOf($it)));
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
@@ -30,6 +31,6 @@ class ContinuationOfTest extends \unittest\TestCase {
     $it->next();
     $it->next();
 
-    $this->assertEquals([], iterator_to_array(new ContinuationOf($it)));
+    Assert::equals([], iterator_to_array(new ContinuationOf($it)));
   }
 }

--- a/src/test/php/util/data/unittest/EachTest.class.php
+++ b/src/test/php/util/data/unittest/EachTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
 use io\streams\MemoryOutputStream;
-use util\cmd\Console;
 use lang\IllegalArgumentException;
+use unittest\Assert;
 use unittest\actions\VerifyThat;
+use util\cmd\Console;
+use util\data\Sequence;
 
 class EachTest extends AbstractSequenceTest {
 
@@ -19,7 +20,7 @@ class EachTest extends AbstractSequenceTest {
     Sequence::of([1, 2, 3, 4])->each(function($e) use(&$collect) {
       $collect[]= $e;
     });
-    $this->assertEquals([1, 2, 3, 4], $collect);
+    Assert::equals([1, 2, 3, 4], $collect);
   }
 
   #[@test]
@@ -28,17 +29,17 @@ class EachTest extends AbstractSequenceTest {
     Sequence::of([1, 2, 3, 4])->each(function($e, $key) use(&$collect) {
       $collect[]= $key;
     });
-    $this->assertEquals([0, 1, 2, 3], $collect);
+    Assert::equals([0, 1, 2, 3], $collect);
   }
 
   #[@test, @values([[[1, 2, 3, 4]], [[]]])]
   public function returns_number_of_processed_elements_with_func($input) {
-    $this->assertEquals(sizeof($input), Sequence::of($input)->each(function($e) { }));
+    Assert::equals(sizeof($input), Sequence::of($input)->each(function($e) { }));
   }
 
   #[@test, @values([[[1, 2, 3, 4]], [[]]])]
   public function returns_number_of_processed_elements_with_null($input) {
-    $this->assertEquals(sizeof($input), Sequence::of($input)->each());
+    Assert::equals(sizeof($input), Sequence::of($input)->each());
   }
 
   #[@test]
@@ -47,7 +48,7 @@ class EachTest extends AbstractSequenceTest {
 
     Sequence::of([1, 2, 3, 4])->each([$out, 'write']);
 
-    $this->assertEquals('1234', $out->getBytes());
+    Assert::equals('1234', $out->getBytes());
   }
 
   #[@test]
@@ -62,7 +63,7 @@ class EachTest extends AbstractSequenceTest {
       Console::$out->setStream($orig);
     }
 
-    $this->assertEquals('1234', $out->getBytes());
+    Assert::equals('1234', $out->getBytes());
   }
 
   #[@test]
@@ -73,7 +74,7 @@ class EachTest extends AbstractSequenceTest {
 
     $bytes= ob_get_contents();
     ob_end_clean();
-    $this->assertEquals('1234', $bytes);
+    Assert::equals('1234', $bytes);
   }
 
   #[@test, @values('invalidArguments'), @expect(IllegalArgumentException::class)]
@@ -90,6 +91,6 @@ class EachTest extends AbstractSequenceTest {
   #  return PHP_VERSION_ID >= 70100 && !defined('HHVM_VERSION_ID');
   #})])]
   public function each_with_void() {
-    $this->assertEquals(4, Sequence::of([1, 2, 3, 4])->each(eval('return function(int $e): void { };')));
+    Assert::equals(4, Sequence::of([1, 2, 3, 4])->each(eval('return function(int $e): void { };')));
   }
 }

--- a/src/test/php/util/data/unittest/EnumerationTest.class.php
+++ b/src/test/php/util/data/unittest/EnumerationTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace util\data\unittest;
 
+use lang\IllegalArgumentException;
+use unittest\Assert;
 use util\data\Enumeration;
 use util\data\Sequence;
-use lang\IllegalArgumentException;
 
-class EnumerationTest extends \unittest\TestCase {
+class EnumerationTest {
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
   public function all_in_array($enumerable, $desc) {
@@ -12,7 +13,7 @@ class EnumerationTest extends \unittest\TestCase {
     foreach (Enumeration::of($enumerable) as $value) {
       $result[]= $value;
     }
-    $this->assertEquals([1, 2, 3], $result, $desc);
+    Assert::equals([1, 2, 3], $result, $desc);
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validMaps')]
@@ -21,7 +22,7 @@ class EnumerationTest extends \unittest\TestCase {
     foreach (Enumeration::of($enumerable) as $key => $value) {
       $result[$key]= $value;
     }
-    $this->assertEquals(['color' => 'green', 'price' => 12.99], $result, $desc);
+    Assert::equals(['color' => 'green', 'price' => 12.99], $result, $desc);
   }
 
   #[@test]
@@ -30,7 +31,7 @@ class EnumerationTest extends \unittest\TestCase {
     foreach (Enumeration::of(Sequence::of([1, 2, 3])) as $value) {
       $result[]= $value;
     }
-    $this->assertEquals([1, 2, 3], $result);
+    Assert::equals([1, 2, 3], $result);
   }
 
   #[@test]
@@ -39,7 +40,7 @@ class EnumerationTest extends \unittest\TestCase {
     foreach (Enumeration::of(function() { return [1, 2, 3]; }) as $value) {
       $result[]= $value;
     }
-    $this->assertEquals([1, 2, 3], $result);
+    Assert::equals([1, 2, 3], $result);
   }
 
   #[@test, @values('util.data.unittest.Enumerables::invalid'), @expect(IllegalArgumentException::class)]
@@ -49,7 +50,7 @@ class EnumerationTest extends \unittest\TestCase {
 
   #[@test]
   public function returns_empty_enumerable_for_null() {
-    $this->assertEquals([], Enumeration::of(null));
+    Assert::equals([], Enumeration::of(null));
   }
 
   #[@test, @expect(IllegalArgumentException::class)]

--- a/src/test/php/util/data/unittest/LimitTest.class.php
+++ b/src/test/php/util/data/unittest/LimitTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\data\Sequence;
 
 class LimitTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -1,30 +1,31 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalStateException;
+use unittest\Assert;
 use util\Filter;
 use util\NoSuchElementException;
 use util\data\Optional;
 
-class OptionalTest extends \unittest\TestCase {
+class OptionalTest {
 
   #[@test]
   public function optional_created_via_of_is_present() {
-    $this->assertTrue(Optional::of('Test')->present());
+    Assert::true(Optional::of('Test')->present());
   }
 
   #[@test]
   public function optional_created_via_of_with_null_is_not_present() {
-    $this->assertFalse(Optional::of(null)->present());
+    Assert::false(Optional::of(null)->present());
   }
 
   #[@test]
   public function empty_optional_is_not_present() {
-    $this->assertFalse(Optional::$EMPTY->present());
+    Assert::false(Optional::$EMPTY->present());
   }
 
   #[@test]
   public function get_returns_value_passed_to_of() {
-    $this->assertEquals('Test', Optional::of('Test')->get());
+    Assert::equals('Test', Optional::of('Test')->get());
   }
 
   #[@test, @expect(NoSuchElementException::class)]
@@ -34,44 +35,44 @@ class OptionalTest extends \unittest\TestCase {
 
   #[@test]
   public function orElse_returns_value_passed_to_of() {
-    $this->assertEquals('Test', Optional::of('Test')->orElse('Failed'));
+    Assert::equals('Test', Optional::of('Test')->orElse('Failed'));
   }
 
   #[@test]
   public function orElse_returns_default_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->orElse('Succeeded'));
+    Assert::equals('Succeeded', Optional::$EMPTY->orElse('Succeeded'));
   }
 
   #[@test]
   public function orUse_returns_value_passed_to_of() {
-    $this->assertEquals('Test', Optional::of('Test')->orUse(function() {
+    Assert::equals('Test', Optional::of('Test')->orUse(function() {
       throw new IllegalStateException('Not reached');
     }));
   }
 
   #[@test]
   public function orUse_invokes_supplier_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->orUse(function() { return 'Succeeded'; }));
+    Assert::equals('Succeeded', Optional::$EMPTY->orUse(function() { return 'Succeeded'; }));
   }
 
   #[@test]
   public function whenAbsent_returns_value_passed_to_of() {
-    $this->assertEquals('Test', Optional::of('Test')->whenAbsent('Failed')->get());
+    Assert::equals('Test', Optional::of('Test')->whenAbsent('Failed')->get());
   }
 
   #[@test]
   public function whenAbsent_returns_value_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent('Succeeded')->get());
+    Assert::equals('Succeeded', Optional::$EMPTY->whenAbsent('Succeeded')->get());
   }
 
   #[@test]
   public function whenAbsent_returns_optionals_value_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent(Optional::of('Succeeded'))->get());
+    Assert::equals('Succeeded', Optional::$EMPTY->whenAbsent(Optional::of('Succeeded'))->get());
   }
 
   #[@test]
   public function whenAbsent_returns_functions_return_value_when_no_value_is_present() {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent(function() { return 'Succeeded'; })->get());
+    Assert::equals('Succeeded', Optional::$EMPTY->whenAbsent(function() { return 'Succeeded'; })->get());
   }
 
   #[@test, @values([
@@ -81,32 +82,32 @@ class OptionalTest extends \unittest\TestCase {
   #  [function() { return \util\data\Optional::$EMPTY; }]
   #])]
   public function whenAbsent_chaining($value) {
-    $this->assertEquals('Succeeded', Optional::$EMPTY->whenAbsent($value)->whenAbsent('Succeeded')->get());
+    Assert::equals('Succeeded', Optional::$EMPTY->whenAbsent($value)->whenAbsent('Succeeded')->get());
   }
 
   #[@test]
   public function can_be_used_in_foreach() {
-    $this->assertEquals(['Test'], iterator_to_array(Optional::of('Test')));
+    Assert::equals(['Test'], iterator_to_array(Optional::of('Test')));
   }
 
   #[@test]
   public function empty_can_be_used_in_foreach() {
-    $this->assertEquals([], iterator_to_array(Optional::$EMPTY));
+    Assert::equals([], iterator_to_array(Optional::$EMPTY));
   }
 
   #[@test]
   public function filter_returns_empty_when_no_value_present() {
-    $this->assertEquals(Optional::$EMPTY, Optional::$EMPTY->filter('is_array'));
+    Assert::equals(Optional::$EMPTY, Optional::$EMPTY->filter('is_array'));
   }
 
   #[@test]
   public function filter_returns_self_when_predicate_matches() {
-    $this->assertEquals([1, 2, 3], Optional::of([1, 2, 3])->filter('is_array')->get());
+    Assert::equals([1, 2, 3], Optional::of([1, 2, 3])->filter('is_array')->get());
   }
 
   #[@test]
   public function filter_returns_empty_when_predicate_does_not_match() {
-    $this->assertEquals(Optional::$EMPTY, Optional::of('test')->filter('is_array'));
+    Assert::equals(Optional::$EMPTY, Optional::of('test')->filter('is_array'));
   }
 
   #[@test]
@@ -114,26 +115,26 @@ class OptionalTest extends \unittest\TestCase {
     $filter= newinstance(Filter::class, [], [
       'accept' => function($value) { return preg_match('/^www/', $value); }
     ]);
-    $this->assertEquals('www.example.com', Optional::of('www.example.com')->filter($filter)->get());
+    Assert::equals('www.example.com', Optional::of('www.example.com')->filter($filter)->get());
   }
 
   #[@test]
   public function map_applies_function_when_value_present() {
-    $this->assertEquals('123', Optional::of([1, 2, 3])->map('implode')->get());
+    Assert::equals('123', Optional::of([1, 2, 3])->map('implode')->get());
   }
 
   #[@test]
   public function map_returns_empty_when_no_value_present() {
-    $this->assertEquals(Optional::$EMPTY, Optional::$EMPTY->map('implode'));
+    Assert::equals(Optional::$EMPTY, Optional::$EMPTY->map('implode'));
   }
 
   #[@test]
   public function toString_for_empty_optional() {
-    $this->assertEquals('util.data.Optional<EMPTY>', Optional::$EMPTY->toString());
+    Assert::equals('util.data.Optional<EMPTY>', Optional::$EMPTY->toString());
   }
 
   #[@test]
   public function toString_for_sequence_of_array() {
-    $this->assertEquals('util.data.Optional@[1, 2, 3]', Optional::of([1, 2, 3])->toString());
+    Assert::equals('util.data.Optional@[1, 2, 3]', Optional::of([1, 2, 3])->toString());
   }
 }

--- a/src/test/php/util/data/unittest/PeekTest.class.php
+++ b/src/test/php/util/data/unittest/PeekTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
 use io\streams\MemoryOutputStream;
-use util\cmd\Console;
 use lang\IllegalArgumentException;
+use unittest\Assert;
 use unittest\actions\VerifyThat;
+use util\cmd\Console;
+use util\data\Sequence;
 
 class PeekTest extends AbstractSequenceTest {
 
@@ -21,7 +22,7 @@ class PeekTest extends AbstractSequenceTest {
       ->peek(function($e) use(&$debug) { $debug[]= $e; })
       ->each()
     ;
-    $this->assertEquals([1, 3], $debug);
+    Assert::equals([1, 3], $debug);
   }
 
   #[@test]
@@ -32,7 +33,7 @@ class PeekTest extends AbstractSequenceTest {
       ->peek(function($e, $key) use(&$debug) { $debug[]= $key; })
       ->each()
     ;
-    $this->assertEquals([0, 2], $debug);
+    Assert::equals([0, 2], $debug);
   }
 
   #[@test]
@@ -49,7 +50,7 @@ class PeekTest extends AbstractSequenceTest {
     }
 
     Console::$out->setStream($orig);    
-    $this->assertEquals('1234', $out->getBytes());
+    Assert::equals('1234', $out->getBytes());
   }
 
   #[@test]
@@ -60,7 +61,7 @@ class PeekTest extends AbstractSequenceTest {
 
     $bytes= ob_get_contents();
     ob_end_clean();
-    $this->assertEquals('1234', $bytes);
+    Assert::equals('1234', $bytes);
   }
 
   #[@test, @values('noncallables'), @expect(IllegalArgumentException::class)]
@@ -72,6 +73,6 @@ class PeekTest extends AbstractSequenceTest {
   #  return PHP_VERSION_ID >= 70100 && !defined('HHVM_VERSION_ID');
   #})])]
   public function each_with_void() {
-    $this->assertEquals(4, Sequence::of([1, 2, 3, 4])->peek(eval('return function(int $e): void { };'))->each());
+    Assert::equals(4, Sequence::of([1, 2, 3, 4])->peek(eval('return function(int $e): void { };'))->each());
   }
 }

--- a/src/test/php/util/data/unittest/SequenceCollectionTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCollectionTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
+use unittest\Assert;
 use util\data\Collector;
+use util\data\Sequence;
 
 class SequenceCollectionTest extends AbstractSequenceTest {
 
@@ -11,7 +12,7 @@ class SequenceCollectionTest extends AbstractSequenceTest {
       function() { return ['total' => 0, 'sum' => 0]; },
       function(&$result, $arg) { $result['total']++; $result['sum']+= $arg; }
     ));
-    $this->assertEquals(2.5, $result['sum'] / $result['total']);
+    Assert::equals(2.5, $result['sum'] / $result['total']);
   }
 
   #[@test]
@@ -21,6 +22,6 @@ class SequenceCollectionTest extends AbstractSequenceTest {
       function(&$result, $arg) { $result.= ', '.$arg; },
       function($result) { return substr($result, 2); }
     ));
-    $this->assertEquals('a, b, c', $result);
+    Assert::equals('a, b, c', $result);
   }
 }

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -1,7 +1,8 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
 use lang\IllegalArgumentException;
+use unittest\Assert;
+use util\data\Sequence;
 
 /**
  * Tests the three Sequence class' creation methods `of()`, `iterate()`
@@ -18,7 +19,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test, @values('util.data.unittest.Enumerables::valid')]
   public function can_create_via_of($input, $name) {
-    $this->assertInstanceOf(Sequence::class, Sequence::of($input), $name);
+    Assert::instance(Sequence::class, Sequence::of($input), $name);
   }
 
   #[@test, @expect(IllegalArgumentException::class), @values('util.data.unittest.Enumerables::invalid')]
@@ -28,7 +29,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test, @values('unaryops')]
   public function can_create_via_iterate($input, $name) {
-    $this->assertInstanceOf(Sequence::class, Sequence::iterate(0, $input), $name);
+    Assert::instance(Sequence::class, Sequence::iterate(0, $input), $name);
   }
 
   #[@test, @expect(IllegalArgumentException::class), @values('noncallables')]
@@ -38,7 +39,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test, @values('suppliers')]
   public function can_create_via_generate($input) {
-    $this->assertInstanceOf(Sequence::class, Sequence::generate($input));
+    Assert::instance(Sequence::class, Sequence::generate($input));
   }
 
   #[@test, @expect(IllegalArgumentException::class), @values('noncallables')]
@@ -48,7 +49,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
 
   #[@test]
   public function passing_null_to_of_yields_an_empty_sequence() {
-    $this->assertEquals(Sequence::$EMPTY, Sequence::of(null));
+    Assert::equals(Sequence::$EMPTY, Sequence::of(null));
   }
 
   #[@test]

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace util\data\unittest;
 
+use lang\IllegalArgumentException;
+use unittest\Assert;
 use util\Filter;
 use util\data\Sequence;
-use lang\IllegalArgumentException;
 
 class SequenceFilteringTest extends AbstractSequenceTest {
 
@@ -39,13 +40,13 @@ class SequenceFilteringTest extends AbstractSequenceTest {
   public function array_index_is_passed_to_function() {
     $keys= [];
     Sequence::of([1, 2, 3])->filter(function($e, $key) use(&$keys) { $keys[]= $key; return true; })->each();
-    $this->assertEquals([0, 1, 2], $keys);
+    Assert::equals([0, 1, 2], $keys);
   }
 
   #[@test]
   public function map_key_is_passed_to_function() {
     $keys= [];
     Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->filter(function($e, $key) use(&$keys) { $keys[]= $key; return true; })->each();
-    $this->assertEquals(['one', 'two', 'three'], $keys);
+    Assert::equals(['one', 'two', 'three'], $keys);
   }
 }

--- a/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
-use util\data\Optional;
 use lang\IllegalArgumentException;
+use unittest\Assert;
+use util\data\Optional;
+use util\data\Sequence;
 
 class SequenceFlatteningTest extends AbstractSequenceTest {
 
@@ -35,14 +36,14 @@ class SequenceFlatteningTest extends AbstractSequenceTest {
   public function array_index_is_passed_to_function() {
     $keys= [];
     Sequence::of([['a', 'b'], ['c', 'd']])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
-    $this->assertEquals([0, 1], $keys);
+    Assert::equals([0, 1], $keys);
   }
 
   #[@test]
   public function map_key_is_passed_to_function() {
     $keys= [];
     Sequence::of(['one' => [1], 'two' => [2], 'three' => [3]])->flatten(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
-    $this->assertEquals(['one', 'two', 'three'], $keys);
+    Assert::equals(['one', 'two', 'three'], $keys);
   }
 
   #[@test]

--- a/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
-use util\XPIterator;
+use unittest\Assert;
 use util\NoSuchElementException;
+use util\XPIterator;
 use util\data\CannotReset;
+use util\data\Sequence;
 
 class SequenceIteratorTest extends AbstractSequenceTest {
 
@@ -23,17 +24,17 @@ class SequenceIteratorTest extends AbstractSequenceTest {
 
   #[@test]
   public function hasNext() {
-    $this->assertTrue(Sequence::of([1])->iterator()->hasNext());
+    Assert::true(Sequence::of([1])->iterator()->hasNext());
   }
 
   #[@test]
   public function next() {
-    $this->assertEquals(1, Sequence::of([1])->iterator()->next());
+    Assert::equals(1, Sequence::of([1])->iterator()->next());
   }
 
   #[@test]
   public function hasNext_returns_false_when_at_end_of_sequence() {
-    $this->assertFalse(Sequence::$EMPTY->iterator()->hasNext());
+    Assert::false(Sequence::$EMPTY->iterator()->hasNext());
   }
 
   #[@test, @expect(NoSuchElementException::class)]
@@ -43,7 +44,7 @@ class SequenceIteratorTest extends AbstractSequenceTest {
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
   public function iterator($input) {
-    $this->assertEquals([1, 2, 3], $this->iterated(Sequence::of($input)->iterator()));
+    Assert::equals([1, 2, 3], $this->iterated(Sequence::of($input)->iterator()));
   }
 
   #[@test, @values('util.data.unittest.Enumerables::fixedArrays')]

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
-use unittest\actions\VerifyThat;
 use lang\IllegalArgumentException;
+use unittest\Assert;
+use unittest\actions\VerifyThat;
+use util\data\Sequence;
 
 class SequenceMappingTest extends AbstractSequenceTest {
 
@@ -25,14 +26,14 @@ class SequenceMappingTest extends AbstractSequenceTest {
   public function array_index_is_passed_to_function() {
     $keys= [];
     Sequence::of([1, 2, 3])->map(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
-    $this->assertEquals([0, 1, 2], $keys);
+    Assert::equals([0, 1, 2], $keys);
   }
 
   #[@test]
   public function map_key_is_passed_to_function() {
     $keys= [];
     Sequence::of(['one' => 1, 'two' => 2, 'three' => 3])->map(function($e, $key) use(&$keys) { $keys[]= $key; return $e; })->each();
-    $this->assertEquals(['one', 'two', 'three'], $keys);
+    Assert::equals(['one', 'two', 'three'], $keys);
   }
 
   #[@test]
@@ -48,13 +49,13 @@ class SequenceMappingTest extends AbstractSequenceTest {
   public function with_generator() {
     $records= Sequence::of([['unit' => 'yellow', 'amount' => 20], ['unit' => 'blue', 'amount' => 19]]);
     $generator= function($record) { yield $record['unit'] => $record['amount']; };
-    $this->assertEquals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
+    Assert::equals(['yellow' => 20, 'blue' => 19], $records->map($generator)->toMap());
   }
 
   #[@test]
   public function with_generator_and_key() {
     $records= Sequence::of(['color' => 'green', 'price' => 12.99]);
     $generator= function($value, $key) { yield strtoupper($key) => $value; };
-    $this->assertEquals(['COLOR' => 'green', 'PRICE' => 12.99], $records->map($generator)->toMap());
+    Assert::equals(['COLOR' => 'green', 'PRICE' => 12.99], $records->map($generator)->toMap());
   }
 }

--- a/src/test/php/util/data/unittest/SequenceReductionTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceReductionTest.class.php
@@ -1,33 +1,34 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\data\Sequence;
 
 class SequenceReductionTest extends AbstractSequenceTest {
 
   #[@test]
   public function returns_identity_for_empty_input() {
-    $this->assertEquals(-1, Sequence::of([])->reduce(-1, function($a, $b) {
+    Assert::equals(-1, Sequence::of([])->reduce(-1, function($a, $b) {
       $this->fail('Should not be called');
     }));
   }
 
   #[@test]
   public function used_for_summing() {
-    $this->assertEquals(10, Sequence::of([1, 2, 3, 4])->reduce(0, function($a, $b) {
+    Assert::equals(10, Sequence::of([1, 2, 3, 4])->reduce(0, function($a, $b) {
       return $a + $b;
     }));
   }
 
   #[@test]
   public function used_for_max() {
-    $this->assertEquals(10, Sequence::of([7, 1, 10, 3])->reduce(0, function($a, $b) {
+    Assert::equals(10, Sequence::of([7, 1, 10, 3])->reduce(0, function($a, $b) {
       return $a < $b ? $b : $a;
     }));
   }
 
   #[@test]
   public function used_for_concatenation() {
-    $this->assertEquals('Hello World', Sequence::of(['Hello', ' ', 'World'])->reduce('', function($a, $b) {
+    Assert::equals('Hello World', Sequence::of(['Hello', ' ', 'World'])->reduce('', function($a, $b) {
       return $a.$b;
     }));
   }

--- a/src/test/php/util/data/unittest/SequenceResultSetTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceResultSetTest.class.php
@@ -13,7 +13,7 @@ class SequenceResultSetTest extends AbstractSequenceTest {
     ['id' => 3, 'name' => 'Test']
   ];
 
-  protected $fetched= [];
+  protected $fetched;
 
   /**
    * Loads result sets in a paged manner
@@ -43,6 +43,7 @@ class SequenceResultSetTest extends AbstractSequenceTest {
 
   #[@test]
   public function three_records() {
+    $this->fetched= [];
     $values= $this->records(3)->map(function($e) { return $e['name']; })->toArray();
     Assert::equals(
       ['fetched' => [0, 3], 'values' => ['Timm', 'Alex', 'Dude', 'Test']],
@@ -52,6 +53,7 @@ class SequenceResultSetTest extends AbstractSequenceTest {
 
   #[@test]
   public function two_records() {
+    $this->fetched= [];
     $values= $this->records(2)->map(function($e) { return $e['name']; })->toArray();
     Assert::equals(
       ['fetched' => [0, 2, 4], 'values' => ['Timm', 'Alex', 'Dude', 'Test']],

--- a/src/test/php/util/data/unittest/SequenceResultSetTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceResultSetTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\data\Sequence;
 
 class SequenceResultSetTest extends AbstractSequenceTest {
@@ -43,7 +44,7 @@ class SequenceResultSetTest extends AbstractSequenceTest {
   #[@test]
   public function three_records() {
     $values= $this->records(3)->map(function($e) { return $e['name']; })->toArray();
-    $this->assertEquals(
+    Assert::equals(
       ['fetched' => [0, 3], 'values' => ['Timm', 'Alex', 'Dude', 'Test']],
       ['fetched' => $this->fetched, 'values' => $values]
     );
@@ -52,7 +53,7 @@ class SequenceResultSetTest extends AbstractSequenceTest {
   #[@test]
   public function two_records() {
     $values= $this->records(2)->map(function($e) { return $e['name']; })->toArray();
-    $this->assertEquals(
+    Assert::equals(
       ['fetched' => [0, 2, 4], 'values' => ['Timm', 'Alex', 'Dude', 'Test']],
       ['fetched' => $this->fetched, 'values' => $values]
     );

--- a/src/test/php/util/data/unittest/SequenceSkipTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSkipTest.class.php
@@ -1,5 +1,6 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\data\Sequence;
 
 class SequenceSkipTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/SequenceSortingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSortingTest.class.php
@@ -1,8 +1,9 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
-use util\Date;
+use unittest\Assert;
 use util\Comparator;
+use util\Date;
+use util\data\Sequence;
 
 class SequenceSortingTest extends AbstractSequenceTest {
 

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace util\data\unittest;
 
+use unittest\Assert;
 use util\cmd\Console;
-use util\data\Sequence;
-use util\data\Optional;
-use util\data\Collector;
 use util\data\CannotReset;
+use util\data\Collector;
+use util\data\Optional;
+use util\data\Sequence;
 
 class SequenceTest extends AbstractSequenceTest {
 
@@ -33,17 +34,17 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function toArray_for_empty_sequence() {
-    $this->assertEquals([], Sequence::$EMPTY->toArray());
+    Assert::equals([], Sequence::$EMPTY->toArray());
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validArrays')]
   public function toArray_returns_elements_as_array($input, $name) {
-    $this->assertEquals([1, 2, 3], Sequence::of($input)->toArray(), $name);
+    Assert::equals([1, 2, 3], Sequence::of($input)->toArray(), $name);
   }
 
   #[@test]
   public function toArray_optionally_accepts_mapper() {
-    $this->assertEquals(
+    Assert::equals(
       [2, 4],
       Sequence::of([1, 2])->toArray(function($v) { return $v * 2; })
     );
@@ -51,17 +52,17 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function toMap_for_empty_sequence() {
-    $this->assertEquals([], Sequence::$EMPTY->toMap());
+    Assert::equals([], Sequence::$EMPTY->toMap());
   }
 
   #[@test, @values('util.data.unittest.Enumerables::validMaps')]
   public function toMap_returns_elements_as_map($input) {
-    $this->assertEquals(['color' => 'green', 'price' => 12.99], Sequence::of($input)->toMap());
+    Assert::equals(['color' => 'green', 'price' => 12.99], Sequence::of($input)->toMap());
   }
 
   #[@test]
   public function toMap_optionally_accepts_mapper() {
-    $this->assertEquals(
+    Assert::equals(
       ['a' => 2, 'b' => 4],
       Sequence::of(['a' => 1, 'b' => 2])->toMap(function($v) { return $v * 2; })
     );
@@ -73,32 +74,32 @@ class SequenceTest extends AbstractSequenceTest {
   #  [4, [1, 2, 3, 4]]
   #])]
   public function count($length, $values) {
-    $this->assertEquals($length, Sequence::of($values)->count());
+    Assert::equals($length, Sequence::of($values)->count());
   }
 
   #[@test]
   public function first_returns_non_present_optional_for_empty_input() {
-    $this->assertFalse(Sequence::of([])->first()->present());
+    Assert::false(Sequence::of([])->first()->present());
   }
 
   #[@test]
   public function first_returns_present_optional_even_for_null() {
-    $this->assertTrue(Sequence::of([null])->first()->present());
+    Assert::true(Sequence::of([null])->first()->present());
   }
 
   #[@test]
   public function first_returns_first_array_element() {
-    $this->assertEquals(1, Sequence::of([1, 2, 3])->first()->get());
+    Assert::equals(1, Sequence::of([1, 2, 3])->first()->get());
   }
 
   #[@test]
   public function first_returns_first_element_to_match_its_filter() {
-    $this->assertEquals(2, Sequence::of([1, 2, 3])->first(function($i) { return 0 === $i % 2; })->get());
+    Assert::equals(2, Sequence::of([1, 2, 3])->first(function($i) { return 0 === $i % 2; })->get());
   }
 
   #[@test]
   public function first_returns_non_present_optional_if_no_element_matches_its_filter() {
-    $this->assertFalse(Sequence::of([1, 3])->first(function($i) { return 0 === $i % 2; })->present());
+    Assert::false(Sequence::of([1, 3])->first(function($i) { return 0 === $i % 2; })->present());
   }
 
   #[@test, @values([
@@ -121,14 +122,14 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function is_useable_inside_foreach() {
-    $this->assertEquals([1, 2, 3], iterator_to_array(Sequence::of([1, 2, 3])));
+    Assert::equals([1, 2, 3], iterator_to_array(Sequence::of([1, 2, 3])));
   }
 
   #[@test, @values([[['a', 'b', 'c', 'd']], [[]]])]
   public function counting($input) {
     $i= 0;
     Sequence::of($input)->counting($i)->each();
-    $this->assertEquals(sizeof($input), $i);
+    Assert::equals(sizeof($input), $i);
   }
 
   #[@test, @values('util.data.unittest.Enumerables::fixedArrays')]
@@ -186,11 +187,11 @@ class SequenceTest extends AbstractSequenceTest {
 
   #[@test]
   public function toString_for_empty_sequence() {
-    $this->assertEquals('util.data.Sequence<EMPTY>', Sequence::$EMPTY->toString());
+    Assert::equals('util.data.Sequence<EMPTY>', Sequence::$EMPTY->toString());
   }
 
   #[@test]
   public function toString_for_sequence_of_array() {
-    $this->assertEquals('util.data.Sequence@[1, 2, 3]', Sequence::of([1, 2, 3])->toString());
+    Assert::equals('util.data.Sequence@[1, 2, 3]', Sequence::of([1, 2, 3])->toString());
   }
 }

--- a/src/test/php/util/data/unittest/TraversalOfTest.class.php
+++ b/src/test/php/util/data/unittest/TraversalOfTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace util\data\unittest;
 
-use util\data\TraversalOf;
-use util\data\CannotReset;
 use lang\IllegalStateException;
+use unittest\Assert;
+use util\data\CannotReset;
+use util\data\TraversalOf;
 
-class TraversalOfTest extends \unittest\TestCase {
+class TraversalOfTest {
 
   #[@test, @values([
   #  [[]],
@@ -12,7 +13,7 @@ class TraversalOfTest extends \unittest\TestCase {
   #  [['key' => 'value']]
   #])]
   public function iteration($input) {
-    $this->assertEquals($input, iterator_to_array(new TraversalOf(new \ArrayIterator($input))));
+    Assert::equals($input, iterator_to_array(new TraversalOf(new \ArrayIterator($input))));
   }
 
   #[@test, @values([

--- a/src/test/php/util/data/unittest/YieldingOfTest.class.php
+++ b/src/test/php/util/data/unittest/YieldingOfTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace util\data\unittest;
 
-use util\data\YieldingOf;
+use unittest\Assert;
 use util\data\CannotReset;
+use util\data\YieldingOf;
 
-class YieldingOfTest extends \unittest\TestCase {
+class YieldingOfTest {
 
   /** @return iterable */
   private function fixtures() {
@@ -16,7 +17,7 @@ class YieldingOfTest extends \unittest\TestCase {
 
   #[@test, @values('fixtures')]
   public function iteration($generator, $expected) {
-    $this->assertEquals($expected, iterator_to_array(new YieldingOf($generator())));
+    Assert::equals($expected, iterator_to_array(new YieldingOf($generator())));
   }
 
   #[@test, @values('fixtures')]


### PR DESCRIPTION
This pull request converts the test suite to use the new baseless tests as implemented in xp-framework/unittest#37 using the script from https://github.com/xp-framework/unittest/issues/36#issuecomment-537234618

## Typical diff

```diff
diff --git ...
index 3ac802e..7a72cc8 100755
--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -1,9 +1,10 @@
 <?php namespace util\data\unittest;
 
-use util\data\Sequence;
+use unittest\Assert;
 use util\data\Collector;
+use util\data\Sequence;
 
-abstract class AbstractSequenceTest extends \unittest\TestCase {
+abstract class AbstractSequenceTest {
 
   /**
    * Assertion helper
@@ -14,7 +15,7 @@ abstract class AbstractSequenceTest extends \unittest\TestCase {
    * @throws unittest.AssertionFailedError
    */
   protected function assertSequence($expected, $sequence, $message= '!=') {
-    $this->assertEquals($expected, $sequence->toArray(), $message);
+    Assert::equals($expected, $sequence->toArray(), $message);
   }
 
   /**
```

* The `unittest.Assert` class is added to the imports
* Imports are sorted alphabetically
* The class is unparented from `unittest.TestCase`
* Assertions are rewritten
* Old setup and teardown methods are left as-is, but annotated with `@before` and `@after`.

## Performance

Before:

```bash
$ xp test src/test/php/
# ...
♥: 495/495 run (0 skipped), 495 succeeded, 0 failed
Memory used: 4283.22 kB (4512.49 kB peak)
Time taken: 0.056 seconds
```

After:

```bash
$ xp test src/test/php/
# ...
♥: 495/495 run (0 skipped), 495 succeeded, 0 failed
Memory used: 4193.88 kB (4440.66 kB peak)
Time taken: 0.056 seconds
```

A slight decrease in memory usage can be seen; otherwise the same.