### PR TITLE
Allow NULL for peek(), map(), filter(), skip() and limit()

### DIFF
--- a/src/main/php/util/data/Optional.class.php
+++ b/src/main/php/util/data/Optional.class.php
@@ -104,6 +104,7 @@ class Optional implements Value, IteratorAggregate {
    */
   public function filter($predicate) {
     if (!$this->present) return self::$EMPTY;
+    if (null === $predicate) return $this;
 
     if ($predicate instanceof Filter || is('util.Filter<?>', $predicate)) {
       $filter= Functions::$APPLY->cast([$predicate, 'accept']);
@@ -124,6 +125,7 @@ class Optional implements Value, IteratorAggregate {
    */
   public function map($function) {
     if (!$this->present) return self::$EMPTY;
+    if (null === $function) return $this;
 
     return self::of(Functions::$APPLY->newInstance($function)->__invoke($this->value));
   }

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -449,7 +449,9 @@ class Sequence implements Value, IteratorAggregate {
    * @throws lang.IllegalArgumentException
    */
   public function peek($action, $args= null) {
-    if (null !== $args) {
+    if (null === $action) {
+      return $this;
+    } else if (null !== $args) {
       $peek= Functions::$RECV->newInstance($action);
       $f= function() use($peek, $args) {
         foreach ($this->elements as $key => $element) {

--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -251,7 +251,9 @@ class Sequence implements Value, \IteratorAggregate {
    * @throws lang.IllegalArgumentException
    */
   public function limit($arg) {
-    if (is_numeric($arg)) {
+    if (null === $arg) {
+      return $this;
+    } else if (is_numeric($arg)) {
       $max= (int)$arg;
       $f= function() use($max) {
         $i= 0;
@@ -289,7 +291,9 @@ class Sequence implements Value, \IteratorAggregate {
    * @throws lang.IllegalArgumentException
    */
   public function skip($arg) {
-    if (is_numeric($arg)) {
+    if (null === $arg) {
+      return $this;
+    } else if (is_numeric($arg)) {
       $max= (int)$arg;
       $f= function() use($max) {
         $i= 0;
@@ -334,7 +338,9 @@ class Sequence implements Value, \IteratorAggregate {
    * @throws lang.IllegalArgumentException
    */
   public function filter($predicate) {
-    if ($predicate instanceof Filter || is('util.Filter<?>', $predicate)) {
+    if (null === $predicate) {
+      return $this;
+    } else if ($predicate instanceof Filter || is('util.Filter<?>', $predicate)) {
       $f= function() use($predicate) {
         foreach ($this->elements as $key => $element) {
           if ($predicate->accept($element)) yield $key => $element;
@@ -367,7 +373,9 @@ class Sequence implements Value, \IteratorAggregate {
    * @throws lang.IllegalArgumentException
    */
   public function map($function) {
-    if (Functions::$APPLY_WITH_KEY->isInstance($function)) {
+    if (null === $function) {
+      return $this;
+    } else if (Functions::$APPLY_WITH_KEY->isInstance($function)) {
       $mapper= Functions::$APPLY_WITH_KEY->cast($function);
       $f= function() use($mapper) {
         foreach ($this->elements as $key => $element) {
@@ -530,7 +538,7 @@ class Sequence implements Value, \IteratorAggregate {
    * @return self
    */
   public function distinct($function= null) {
-    $hash= Functions::$APPLY->newInstance($function ?: 'util.Objects::hashOf');
+    $hash= Functions::$APPLY->newInstance($function ?? 'util.Objects::hashOf');
     return self::of(function() use($hash) {
       $set= [];
       foreach ($this->elements as $e) {

--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -69,7 +69,7 @@ abstract class AbstractSequenceTest {
    */
   protected function noncallables() {
     return [
-      [null], [''], ['...'], [-1], [0], [1], [0.5], [false], [true],
+      [''], ['...'], [-1], [0], [1], [0.5], [false], [true],
       [new Name('...')], [$this],
       [[]], [[$this]], [['xp']], [['xp', 'g']], [[$this, 'getName', 'excess-element']],
       ['xp:g'], ['xp::'], ['xp::g'], ['::gc'], ['typeo']

--- a/src/test/php/util/data/unittest/EachTest.class.php
+++ b/src/test/php/util/data/unittest/EachTest.class.php
@@ -9,11 +9,6 @@ use util\data\Sequence;
 
 class EachTest extends AbstractSequenceTest {
 
-  /** @return var[][] */
-  protected function invalidArguments() {
-    return array_filter($this->noncallables(), function($args) { return null !== $args[0]; });
-  }
-
   #[Test]
   public function each() {
     $collect= [];
@@ -77,7 +72,7 @@ class EachTest extends AbstractSequenceTest {
     Assert::equals('1234', $bytes);
   }
 
-  #[Test, Values('invalidArguments'), Expect(IllegalArgumentException::class)]
+  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->each($noncallable);
   }

--- a/src/test/php/util/data/unittest/LimitTest.class.php
+++ b/src/test/php/util/data/unittest/LimitTest.class.php
@@ -11,6 +11,11 @@ class LimitTest extends AbstractSequenceTest {
   }
 
   #[Test]
+  public function no_limit() {
+    $this->assertSequence([1, 2, 3], Sequence::of([1, 2, 3])->limit(null));
+  }
+
+  #[Test]
   public function stops_at_nth_iterator_element() {
     $this->assertSequence([1, 2], Sequence::iterate(1, function($i) { return ++$i; })->limit(2));
   }

--- a/src/test/php/util/data/unittest/LimitTest.class.php
+++ b/src/test/php/util/data/unittest/LimitTest.class.php
@@ -11,11 +11,6 @@ class LimitTest extends AbstractSequenceTest {
   }
 
   #[Test]
-  public function no_limit() {
-    $this->assertSequence([1, 2, 3], Sequence::of([1, 2, 3])->limit(null));
-  }
-
-  #[Test]
   public function stops_at_nth_iterator_element() {
     $this->assertSequence([1, 2], Sequence::iterate(1, function($i) { return ++$i; })->limit(2));
   }
@@ -34,5 +29,11 @@ class LimitTest extends AbstractSequenceTest {
   #[Test]
   public function receives_offset() {
     $this->assertSequence([1, 2], Sequence::of([1, 2, 3, 4])->limit(function($e, $offset) { return $offset >= 2; }));
+  }
+
+  #[Test]
+  public function no_skipping() {
+    $sequence= Sequence::of([1, 2, 3, 4]);
+    Assert::true($sequence === $sequence->limit(null));
   }
 }

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -113,6 +113,12 @@ class OptionalTest {
   }
 
   #[Test]
+  public function filter_returns_optional_instance_with_null() {
+    $optional= Optional::of('test')->filter(null);
+    Assert::true($optional === $optional);
+  }
+
+  #[Test]
   public function filter_with_filter_instance() {
     $filter= new class() implements Filter {
       public function accept($value) { return preg_match('/^www/', $value); }
@@ -128,6 +134,12 @@ class OptionalTest {
   #[Test]
   public function map_returns_empty_when_no_value_present() {
     Assert::equals(Optional::$EMPTY, Optional::$EMPTY->map('implode'));
+  }
+
+  #[Test]
+  public function map_returns_optional_instance_with_null() {
+    $optional= Optional::of('test')->map(null);
+    Assert::true($optional === $optional);
   }
 
   #[Test]

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -114,8 +114,8 @@ class OptionalTest {
 
   #[Test]
   public function filter_returns_optional_instance_with_null() {
-    $optional= Optional::of('test')->filter(null);
-    Assert::true($optional === $optional);
+    $optional= Optional::of('test');
+    Assert::true($optional === $optional->filter(null));
   }
 
   #[Test]
@@ -138,8 +138,8 @@ class OptionalTest {
 
   #[Test]
   public function map_returns_optional_instance_with_null() {
-    $optional= Optional::of('test')->map(null);
-    Assert::true($optional === $optional);
+    $optional= Optional::of('test');
+    Assert::true($optional === $optional->map(null));
   }
 
   #[Test]

--- a/src/test/php/util/data/unittest/PeekTest.class.php
+++ b/src/test/php/util/data/unittest/PeekTest.class.php
@@ -9,6 +9,13 @@ use util\data\Sequence;
 
 class PeekTest extends AbstractSequenceTest {
 
+  /** @return iterable */
+  private function nonpeekers() {
+    foreach ($this->noncallables() as $value) {
+      if ([null] !== $value) yield $value;
+    }
+  }
+
   #[Test, Expect(IllegalArgumentException::class)]
   public function invalid() {
     Sequence::$EMPTY->peek('@non-existant-func@');
@@ -64,7 +71,13 @@ class PeekTest extends AbstractSequenceTest {
     Assert::equals('1234', $bytes);
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test]
+  public function peek_is_noop_when_given_null() {
+    $sequence= Sequence::of([]);
+    Assert::true($sequence === $sequence->peek(null));
+  }
+
+  #[Test, Values('nonpeekers'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->peek($noncallable);
   }

--- a/src/test/php/util/data/unittest/PeekTest.class.php
+++ b/src/test/php/util/data/unittest/PeekTest.class.php
@@ -9,13 +9,6 @@ use util\data\Sequence;
 
 class PeekTest extends AbstractSequenceTest {
 
-  /** @return iterable */
-  private function nonpeekers() {
-    foreach ($this->noncallables() as $value) {
-      if ([null] !== $value) yield $value;
-    }
-  }
-
   #[Test, Expect(IllegalArgumentException::class)]
   public function invalid() {
     Sequence::$EMPTY->peek('@non-existant-func@');
@@ -77,7 +70,7 @@ class PeekTest extends AbstractSequenceTest {
     Assert::true($sequence === $sequence->peek(null));
   }
 
-  #[Test, Values('nonpeekers'), Expect(IllegalArgumentException::class)]
+  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->peek($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -37,6 +37,11 @@ class SequenceCreationTest extends AbstractSequenceTest {
     Sequence::iterate(0, $input);
   }
 
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function null_for_iterate() {
+    Sequence::iterate(0, null);
+  }
+
   #[Test, Values('suppliers')]
   public function can_create_via_generate($input) {
     Assert::instance(Sequence::class, Sequence::generate($input));
@@ -45,6 +50,11 @@ class SequenceCreationTest extends AbstractSequenceTest {
   #[Test, Expect(IllegalArgumentException::class), Values('noncallables')]
   public function invalid_type_for_generate($input) {
     Sequence::generate($input);
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function null_for_generate() {
+    Sequence::generate(null);
   }
 
   #[Test]

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -39,8 +39,9 @@ class SequenceFilteringTest extends AbstractSequenceTest {
   }
 
   #[Test]
-  public function with_null() {
-    $this->assertSequence([1, 2, 3, 4], Sequence::of([1, 2, 3, 4])->filter(null));
+  public function with_null_is_noop() {
+    $sequence= Sequence::of([1, 2, 3, 4]);
+    Assert::true($sequence === $sequence->filter(null));
   }
 
   #[Test, Values('nonfilters'), Expect(IllegalArgumentException::class)]

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -7,13 +7,6 @@ use util\data\Sequence;
 
 class SequenceFilteringTest extends AbstractSequenceTest {
 
-  /** @return iterable */
-  private function nonfilters() {
-    foreach ($this->noncallables() as $value) {
-      if ([null] !== $value) yield $value;
-    }
-  }
-
   #[Test]
   public function with_function() {
     $this->assertSequence([2, 4], Sequence::of([1, 2, 3, 4])->filter(function($e) { return 0 === $e % 2; }));
@@ -44,7 +37,7 @@ class SequenceFilteringTest extends AbstractSequenceTest {
     Assert::true($sequence === $sequence->filter(null));
   }
 
-  #[Test, Values('nonfilters'), Expect(IllegalArgumentException::class)]
+  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->filter($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -7,6 +7,13 @@ use util\data\Sequence;
 
 class SequenceFilteringTest extends AbstractSequenceTest {
 
+  /** @return iterable */
+  private function nonfilters() {
+    foreach ($this->noncallables() as $value) {
+      if ([null] !== $value) yield $value;
+    }
+  }
+
   #[Test]
   public function with_function() {
     $this->assertSequence([2, 4], Sequence::of([1, 2, 3, 4])->filter(function($e) { return 0 === $e % 2; }));
@@ -31,7 +38,12 @@ class SequenceFilteringTest extends AbstractSequenceTest {
     ])));
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test]
+  public function with_null() {
+    $this->assertSequence([1, 2, 3, 4], Sequence::of([1, 2, 3, 4])->filter(null));
+  }
+
+  #[Test, Values('nonfilters'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->filter($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
@@ -25,9 +25,6 @@ class SequenceFlatteningTest extends AbstractSequenceTest {
 
   #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
   public function flatten_raises_exception_when_given($noncallable) {
-    if (null === $noncallable) {
-      throw new IllegalArgumentException('Valid use-case');
-    }
     Sequence::of([])->flatten($noncallable);
   }
 

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -7,6 +7,13 @@ use util\data\Sequence;
 
 class SequenceMappingTest extends AbstractSequenceTest {
 
+  /** @return iterable */
+  private function nonmappers() {
+    foreach ($this->noncallables() as $value) {
+      if ([null] !== $value) yield $value;
+    }
+  }
+
   #[Test]
   public function with_function() {
     $this->assertSequence([2, 4, 6, 8], Sequence::of([1, 2, 3, 4])->map(function($e) { return $e * 2; }));
@@ -17,7 +24,12 @@ class SequenceMappingTest extends AbstractSequenceTest {
     $this->assertSequence([1.0, 2.0, 3.0], Sequence::of([1.9, 2.5, 3.1])->map('floor'));
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test]
+  public function with_null() {
+    $this->assertSequence([1, 2, 3, 4], Sequence::of([1, 2, 3, 4])->map(null));
+  }
+
+  #[Test, Values('nonmappers'), Expect(IllegalArgumentException::class)]
   public function map_raises_exception_when_given($noncallable) {
     Sequence::of([])->map($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -25,8 +25,9 @@ class SequenceMappingTest extends AbstractSequenceTest {
   }
 
   #[Test]
-  public function with_null() {
-    $this->assertSequence([1, 2, 3, 4], Sequence::of([1, 2, 3, 4])->map(null));
+  public function with_null_is_noop() {
+    $sequence= Sequence::of([1, 2, 3, 4]);
+    Assert::true($sequence === $sequence->map(null));
   }
 
   #[Test, Values('nonmappers'), Expect(IllegalArgumentException::class)]

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -7,13 +7,6 @@ use util\data\Sequence;
 
 class SequenceMappingTest extends AbstractSequenceTest {
 
-  /** @return iterable */
-  private function nonmappers() {
-    foreach ($this->noncallables() as $value) {
-      if ([null] !== $value) yield $value;
-    }
-  }
-
   #[Test]
   public function with_function() {
     $this->assertSequence([2, 4, 6, 8], Sequence::of([1, 2, 3, 4])->map(function($e) { return $e * 2; }));
@@ -30,7 +23,7 @@ class SequenceMappingTest extends AbstractSequenceTest {
     Assert::true($sequence === $sequence->map(null));
   }
 
-  #[Test, Values('nonmappers'), Expect(IllegalArgumentException::class)]
+  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
   public function map_raises_exception_when_given($noncallable) {
     Sequence::of([])->map($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceSkipTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSkipTest.class.php
@@ -11,6 +11,11 @@ class SequenceSkipTest extends AbstractSequenceTest {
   }
 
   #[Test]
+  public function no_skipping() {
+    $this->assertSequence([1, 2, 3, 4], Sequence::of([1, 2, 3, 4])->skip(null));
+  }
+
+  #[Test]
   public function excludes_elements_when_given_closure_returns_true() {
     $this->assertSequence([3, 4], Sequence::of([1, 2, 3, 4])->skip(function($e) { return $e < 3; }));
   }

--- a/src/test/php/util/data/unittest/SequenceSkipTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSkipTest.class.php
@@ -11,11 +11,6 @@ class SequenceSkipTest extends AbstractSequenceTest {
   }
 
   #[Test]
-  public function no_skipping() {
-    $this->assertSequence([1, 2, 3, 4], Sequence::of([1, 2, 3, 4])->skip(null));
-  }
-
-  #[Test]
   public function excludes_elements_when_given_closure_returns_true() {
     $this->assertSequence([3, 4], Sequence::of([1, 2, 3, 4])->skip(function($e) { return $e < 3; }));
   }
@@ -23,5 +18,11 @@ class SequenceSkipTest extends AbstractSequenceTest {
   #[Test]
   public function receives_offset() {
     $this->assertSequence([3, 4], Sequence::of([1, 2, 3, 4])->skip(function($e, $offset) { return $offset < 2; }));
+  }
+
+  #[Test]
+  public function no_skipping() {
+    $sequence= Sequence::of([1, 2, 3, 4]);
+    Assert::true($sequence === $sequence->skip(null));
   }
 }


### PR DESCRIPTION
This allows for easier composability.

* [x] Sequence
* [x] Optional

## Example

```php
// Starting out here
Sequence::of($input)
  ->filter($filter)
  ->map(...)
  ->each(...)
;

// If we want filter optional, we would do this (and live with the slight performance impact)
Sequence::of($input)
  ->filter($filter ?? fn() => true)
  ->map(...)
  ->each(...)
;

// ...or this (and live with the absolutely ugly code)
$seq= Sequence::of($input);
$filter && $seq= $seq->filter($filter);
$seq->map(...)->each(...);
```

When this pull request is merged, the code can now be rewritten back to the starting positon. The `filter(null)` call yields the sequence instance it is called on and thus does not have a sequence runtime performance hit.