### PR TITLE
Migrate test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,13 @@ jobs:
       run: git config --system core.autocrlf false; git config --system core.eol lf
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up PHP ${{ matrix.php-versions }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
         ini-values: date.timezone=Europe/Berlin
-
-    - name: Setup Problem Matchers for PHP
-      run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
 
     - name: Validate composer.json and composer.lock
       run: composer validate
@@ -43,7 +40,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2.1.3
+      uses: actions/cache@v3
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -56,4 +53,4 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev" : {
-    "xp-framework/unittest": "^11.1"
+    "xp-framework/test": "^1.2"
   },
   "autoload" : {
     "files" : ["src/main/php/autoload.php"]

--- a/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
+++ b/src/test/php/util/data/unittest/AbstractSequenceTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\Assert;
+use test\Assert;
 use util\data\{Collector, Sequence};
 
 abstract class AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/AggregationsTest.class.php
+++ b/src/test/php/util/data/unittest/AggregationsTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\data\{Aggregations, Sequence};
 
 class AggregationsTest {

--- a/src/test/php/util/data/unittest/BoundariesTest.class.php
+++ b/src/test/php/util/data/unittest/BoundariesTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\data\Sequence;
 use util\{Comparator, Date};
 
@@ -19,12 +19,12 @@ class BoundariesTest extends AbstractSequenceTest {
     yield [function($a, $b) { return $b->compareTo($a); }];
   }
 
-  #[Test, Values('values')]
+  #[Test, Values(from: 'values')]
   public function min($min, $max, $values) {
     Assert::equals($min, Sequence::of($values)->min());
   }
 
-  #[Test, Values('comparators')]
+  #[Test, Values(from: 'comparators')]
   public function min_using($comparator) {
     Assert::equals(
       new Date('1977-12-14'),
@@ -32,12 +32,12 @@ class BoundariesTest extends AbstractSequenceTest {
     );
   }
 
-  #[Test, Values('values')]
+  #[Test, Values(from: 'values')]
   public function max($min, $max, $values) {
     Assert::equals($max, Sequence::of($values)->max());
   }
 
-  #[Test, Values('comparators')]
+  #[Test, Values(from: 'comparators')]
   public function max_using($comparator) {
     Assert::equals(
       new Date('2014-07-17'),

--- a/src/test/php/util/data/unittest/CollectorsTest.class.php
+++ b/src/test/php/util/data/unittest/CollectorsTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\XPClass;
-use unittest\{Assert, Before, Test, Values};
+use test\{Assert, Before, Test, Values};
 use util\collections\{HashSet, HashTable, Vector};
 use util\data\{Collector, Collectors, Sequence};
 
@@ -68,7 +68,7 @@ class CollectorsTest {
     ];
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toList($nameOf) {
     Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map($nameOf)
@@ -77,7 +77,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toList_with_extraction($nameOf) {
     Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->collect(Collectors::toList($nameOf))
@@ -85,7 +85,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toSet($nameOf) {
     Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map($nameOf)
@@ -94,7 +94,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toSet_with_extraction($nameOf) {
     Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->collect(Collectors::toSet($nameOf))
@@ -102,7 +102,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toCollection_with_HashSet_class($nameOf) {
     Assert::equals(['Timm', 'Alex', 'Dude'], Sequence::of($this->people)
       ->map($nameOf)
@@ -111,7 +111,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toMap($nameOf) {
     $map= new HashTable();
     $map[1549]= 'Timm';
@@ -124,7 +124,7 @@ class CollectorsTest {
     )));
   }
 
-  #[Test, Values('employeesName')]
+  #[Test, Values(from: 'employeesName')]
   public function toMap_uses_complete_value_if_value_function_omitted($nameOf) {
     $map= new HashTable();
     $map['Timm']= $this->people[1549];
@@ -165,14 +165,14 @@ class CollectorsTest {
     Assert::equals(['COLOR' => 'green', 'PRICE' => 12.99], $result);
   }
 
-  #[Test, Values('employeesYears')]
+  #[Test, Values(from: 'employeesYears')]
   public function summing_years($yearsOf) {
     Assert::equals(33, Sequence::of($this->people)
       ->collect(Collectors::summing($yearsOf))
     );
   }
 
-  #[Test, Values('employeesYears')]
+  #[Test, Values(from: 'employeesYears')]
   public function summing_elements($yearsOf) {
     Assert::equals(33, Sequence::of($this->people)
       ->map($yearsOf)
@@ -180,14 +180,14 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesYears')]
+  #[Test, Values(from: 'employeesYears')]
   public function averaging_years($yearsOf) {
     Assert::equals(11, Sequence::of($this->people)
       ->collect(Collectors::averaging($yearsOf))
     );
   }
 
-  #[Test, Values('employeesYears')]
+  #[Test, Values(from: 'employeesYears')]
   public function averaging_elements($yearsOf) {
     Assert::equals(11, Sequence::of($this->people)
       ->map($yearsOf)
@@ -202,7 +202,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesDepartment')]
+  #[Test, Values(from: 'employeesDepartment')]
   public function mapping_by_department($departmentOf) {
     Assert::equals(new Vector(['B', 'I', 'I']), Sequence::of($this->people)
       ->collect(Collectors::mapping($departmentOf))
@@ -233,7 +233,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('employeesDepartment')]
+  #[Test, Values(from: 'employeesDepartment')]
   public function groupingBy($departmentOf) {
     $this->assertHashTable(
       ['B' => new Vector([$this->people[1549]]), 'I' => new Vector([$this->people[1552], $this->people[6100]])],
@@ -261,7 +261,7 @@ class CollectorsTest {
     );
   }
 
-  #[Test, Values('dinosaurEmployees')]
+  #[Test, Values(from: 'dinosaurEmployees')]
   public function partitioningBy($moreThanTen) {
     $this->assertHashTable(
       [true => new Vector([$this->people[1549], $this->people[1552]]), false => new Vector([$this->people[6100]])],

--- a/src/test/php/util/data/unittest/ContinuationOfTest.class.php
+++ b/src/test/php/util/data/unittest/ContinuationOfTest.class.php
@@ -1,11 +1,12 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\data\{ContinuationOf, Sequence};
 
 class ContinuationOfTest {
+  use Enumerables;
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function at_beginning($input) {
     $it= Sequence::of($input)->getIterator();
     $it->rewind();
@@ -13,7 +14,7 @@ class ContinuationOfTest {
     Assert::equals([0 => 1, 1 => 2, 2 => 3], iterator_to_array(new ContinuationOf($it)));
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function after_first($input) {
     $it= Sequence::of($input)->getIterator();
     $it->rewind();
@@ -22,7 +23,7 @@ class ContinuationOfTest {
     Assert::equals([1 => 2, 2 => 3], iterator_to_array(new ContinuationOf($it)));
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function at_end($input) {
     $it= Sequence::of($input)->getIterator();
     $it->rewind();

--- a/src/test/php/util/data/unittest/EachTest.class.php
+++ b/src/test/php/util/data/unittest/EachTest.class.php
@@ -2,8 +2,8 @@
 
 use io\streams\MemoryOutputStream;
 use lang\IllegalArgumentException;
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Expect, Test, Values};
+use test\verify\Runtime;
+use test\{Action, Assert, Expect, Test, Values};
 use util\cmd\Console;
 use util\data\Sequence;
 
@@ -72,7 +72,7 @@ class EachTest extends AbstractSequenceTest {
     Assert::equals('1234', $bytes);
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test, Values(from: 'noncallables'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->each($noncallable);
   }
@@ -82,7 +82,7 @@ class EachTest extends AbstractSequenceTest {
     Sequence::of([])->each(null, []);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1.0")')]
+  #[Test, Runtime(php: '>=7.1.0')]
   public function each_with_void() {
     Assert::equals(4, Sequence::of([1, 2, 3, 4])->each(eval('return function(int $e): void { };')));
   }

--- a/src/test/php/util/data/unittest/Enumerables.class.php
+++ b/src/test/php/util/data/unittest/Enumerables.class.php
@@ -9,11 +9,10 @@ use util\data\Sequence;
  * their definition involves new syntax unparseable with previous PHP versions, 
  * wrapped in eval() statements.
  *
- * @see   xp://util.data.unittest.EnumerationTest
- * @see   xp://util.data.unittest.AbstractSequenceTest
- * @see   php://generators
+ * @see   util.data.unittest.EnumerationTest
+ * @see   util.data.unittest.AbstractSequenceTest
  */
-abstract class Enumerables {
+trait Enumerables {
 
   /**
    * Returns valid arguments for the `of()` method.

--- a/src/test/php/util/data/unittest/EnumerationTest.class.php
+++ b/src/test/php/util/data/unittest/EnumerationTest.class.php
@@ -1,12 +1,13 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\data\{Enumeration, Sequence};
 
 class EnumerationTest {
+  use Enumerables;
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function all_in_array($enumerable, $desc) {
     $result= [];
     foreach (Enumeration::of($enumerable) as $value) {
@@ -15,7 +16,7 @@ class EnumerationTest {
     Assert::equals([1, 2, 3], $result, $desc);
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validMaps')]
+  #[Test, Values(from: 'validMaps')]
   public function all_in_map($enumerable, $desc) {
     $result= [];
     foreach (Enumeration::of($enumerable) as $key => $value) {
@@ -42,7 +43,7 @@ class EnumerationTest {
     Assert::equals([1, 2, 3], $result);
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::invalid'), Expect(IllegalArgumentException::class)]
+  #[Test, Values(from: 'invalid'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($value) {
     Enumeration::of($value);
   }

--- a/src/test/php/util/data/unittest/LimitTest.class.php
+++ b/src/test/php/util/data/unittest/LimitTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\data\Sequence;
 
 class LimitTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/OptionalTest.class.php
+++ b/src/test/php/util/data/unittest/OptionalTest.class.php
@@ -1,9 +1,9 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalStateException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\Filter;
-use util\data\{Optional, NoSuchElement};
+use util\data\{NoSuchElement, Optional};
 
 class OptionalTest {
 
@@ -82,7 +82,7 @@ class OptionalTest {
     Assert::equals('Succeeded', Optional::$EMPTY->whenAbsent(function() { return 'Succeeded'; })->get());
   }
 
-  #[Test, Values('emptyValues')]
+  #[Test, Values(from: 'emptyValues')]
   public function whenAbsent_chaining($value) {
     Assert::equals('Succeeded', Optional::$EMPTY->whenAbsent($value)->whenAbsent('Succeeded')->get());
   }

--- a/src/test/php/util/data/unittest/PeekTest.class.php
+++ b/src/test/php/util/data/unittest/PeekTest.class.php
@@ -2,8 +2,8 @@
 
 use io\streams\MemoryOutputStream;
 use lang\IllegalArgumentException;
-use unittest\actions\RuntimeVersion;
-use unittest\{Action, Assert, Expect, Test, Values};
+use test\verify\Runtime;
+use test\{Action, Assert, Expect, Test, Values};
 use util\cmd\Console;
 use util\data\Sequence;
 
@@ -68,12 +68,12 @@ class PeekTest extends AbstractSequenceTest {
     Assert::true($sequence === $sequence->peek(null));
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test, Values(from: 'noncallables'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->peek($noncallable);
   }
 
-  #[Test, Action(eval: 'new RuntimeVersion(">=7.1.0")')]
+  #[Test, Runtime(php: '>=7.1.0')]
   public function each_with_void() {
     Assert::equals(4, Sequence::of([1, 2, 3, 4])->peek(eval('return function(int $e): void { };'))->each());
   }

--- a/src/test/php/util/data/unittest/SequenceCollectionTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCollectionTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\data\{Collector, Sequence};
 
 class SequenceCollectionTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\data\Sequence;
 
 /**
@@ -11,28 +11,29 @@ use util\data\Sequence;
  * @see  xp://util.data.Sequence
  */
 class SequenceCreationTest extends AbstractSequenceTest {
+  use Enumerables;
 
   #[Test, Expect(IllegalArgumentException::class)]
   public function missing_argument() {
     Sequence::of();
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::valid')]
+  #[Test, Values(from: 'valid')]
   public function can_create_via_of($input, $name) {
     Assert::instance(Sequence::class, Sequence::of($input), $name);
   }
 
-  #[Test, Expect(IllegalArgumentException::class), Values('util.data.unittest.Enumerables::invalid')]
+  #[Test, Expect(IllegalArgumentException::class), Values(from: 'invalid')]
   public function invalid_type_for_of($input) {
     Sequence::of($input);
   }
 
-  #[Test, Values('unaryops')]
+  #[Test, Values(from: 'unaryops')]
   public function can_create_via_iterate($input, $name) {
     Assert::instance(Sequence::class, Sequence::iterate(0, $input), $name);
   }
 
-  #[Test, Expect(IllegalArgumentException::class), Values('noncallables')]
+  #[Test, Expect(IllegalArgumentException::class), Values(from: 'noncallables')]
   public function invalid_type_for_iterate($input) {
     Sequence::iterate(0, $input);
   }
@@ -42,12 +43,12 @@ class SequenceCreationTest extends AbstractSequenceTest {
     Sequence::iterate(0, null);
   }
 
-  #[Test, Values('suppliers')]
+  #[Test, Values(from: 'suppliers')]
   public function can_create_via_generate($input) {
     Assert::instance(Sequence::class, Sequence::generate($input));
   }
 
-  #[Test, Expect(IllegalArgumentException::class), Values('noncallables')]
+  #[Test, Expect(IllegalArgumentException::class), Values(from: 'noncallables')]
   public function invalid_type_for_generate($input) {
     Sequence::generate($input);
   }

--- a/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFilteringTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\Filter;
 use util\data\Sequence;
 
@@ -37,7 +37,7 @@ class SequenceFilteringTest extends AbstractSequenceTest {
     Assert::true($sequence === $sequence->filter(null));
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test, Values(from: 'noncallables'), Expect(IllegalArgumentException::class)]
   public function raises_exception_when_given($noncallable) {
     Sequence::of([])->filter($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceFlatteningTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\data\{Optional, Sequence};
 
 class SequenceFlatteningTest extends AbstractSequenceTest {
@@ -23,7 +23,7 @@ class SequenceFlatteningTest extends AbstractSequenceTest {
     $this->assertSequence(['a', 'b'], Sequence::of([Optional::of('a'), Optional::$EMPTY, Optional::of('b')])->flatten());
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test, Values(from: 'noncallables'), Expect(IllegalArgumentException::class)]
   public function flatten_raises_exception_when_given($noncallable) {
     Sequence::of([])->flatten($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceIteratorTest.class.php
@@ -1,10 +1,11 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Expect, Test, Values};
+use test\{Assert, Expect, Test, Values};
 use util\XPIterator;
-use util\data\{CannotReset, Sequence, NoSuchElement};
+use util\data\{CannotReset, NoSuchElement, Sequence};
 
 class SequenceIteratorTest extends AbstractSequenceTest {
+  use Enumerables;
 
   /**
    * Collects all values in an iterator in an array
@@ -40,19 +41,19 @@ class SequenceIteratorTest extends AbstractSequenceTest {
     Sequence::$EMPTY->iterator()->next();
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function iterator($input) {
     Assert::equals([1, 2, 3], $this->iterated(Sequence::of($input)->iterator()));
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::fixedArrays')]
+  #[Test, Values(from: 'fixedArrays')]
   public function may_iterate_sequence_based_on_a_fixed_enumerable_more_than_once($input) {
     $seq= Sequence::of($input);
     $this->iterated($seq->iterator());
     $this->iterated($seq->iterator());
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_iterate_sequence_based_on_a_streamed_enumerable_more_than_once($input) {
     $seq= Sequence::of($input);
     $this->iterated($seq->iterator());
@@ -62,7 +63,7 @@ class SequenceIteratorTest extends AbstractSequenceTest {
     });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function sequence_of_iterator($input) {
     $this->assertSequence([1, 2, 3], Sequence::of(Sequence::of($input)->iterator()));
   }

--- a/src/test/php/util/data/unittest/SequenceMappingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceMappingTest.class.php
@@ -1,8 +1,8 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalArgumentException;
-use unittest\actions\VerifyThat;
-use unittest\{Assert, Expect, Test, Values};
+use test\verify\Condition;
+use test\{Assert, Expect, Test, Values};
 use util\data\Sequence;
 
 class SequenceMappingTest extends AbstractSequenceTest {
@@ -23,7 +23,7 @@ class SequenceMappingTest extends AbstractSequenceTest {
     Assert::true($sequence === $sequence->map(null));
   }
 
-  #[Test, Values('noncallables'), Expect(IllegalArgumentException::class)]
+  #[Test, Values(from: 'noncallables'), Expect(IllegalArgumentException::class)]
   public function map_raises_exception_when_given($noncallable) {
     Sequence::of([])->map($noncallable);
   }

--- a/src/test/php/util/data/unittest/SequenceReductionTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceReductionTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test, Values};
 use util\Date;
 use util\data\Sequence;
 

--- a/src/test/php/util/data/unittest/SequenceResultSetTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceResultSetTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\data\Sequence;
 
 class SequenceResultSetTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/SequenceSkipTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSkipTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\data\Sequence;
 
 class SequenceSkipTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/SequenceSortingTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceSortingTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\data\Sequence;
 use util\{Comparator, Date};
 

--- a/src/test/php/util/data/unittest/SequenceTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceTest.class.php
@@ -1,11 +1,12 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalStateException;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\cmd\Console;
-use util\data\{CannotReset, Collector, Optional, Sequence, NoSuchElement, TooManyElements};
+use util\data\{CannotReset, Collector, NoSuchElement, Optional, Sequence, TooManyElements};
 
 class SequenceTest extends AbstractSequenceTest {
+  use Enumerables;
 
   /**
    * Assertion helper
@@ -17,9 +18,8 @@ class SequenceTest extends AbstractSequenceTest {
    */
   protected function assertNotTwice($seq, $func) {
     $func($seq);
-    Assert::throws(CannotReset::class, function() use($seq, $func) {
-      $func($seq);
-    });
+
+    Assert::that(function() use($seq, $func) { $func($seq); })->throws(CannotReset::class);
   }
 
   #[Test]
@@ -32,7 +32,7 @@ class SequenceTest extends AbstractSequenceTest {
     Assert::equals([], Sequence::$EMPTY->toArray());
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validArrays')]
+  #[Test, Values(from: 'validArrays')]
   public function toArray_returns_elements_as_array($input, $name) {
     Assert::equals([1, 2, 3], Sequence::of($input)->toArray(), $name);
   }
@@ -50,7 +50,7 @@ class SequenceTest extends AbstractSequenceTest {
     Assert::equals([], Sequence::$EMPTY->toMap());
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::validMaps')]
+  #[Test, Values(from: 'validMaps')]
   public function toMap_returns_elements_as_map($input) {
     Assert::equals(['color' => 'green', 'price' => 12.99], Sequence::of($input)->toMap());
   }
@@ -156,44 +156,44 @@ class SequenceTest extends AbstractSequenceTest {
     Assert::equals(sizeof($input), $i);
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::fixedArrays')]
+  #[Test, Values(from: 'fixedArrays')]
   public function may_use_sequence_based_on_a_fixed_enumerable_more_than_once($input) {
     $seq= Sequence::of($input);
     $seq->each();
     $seq->each();
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_toArray_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->toArray(); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_each_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->each(); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_first_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->first(); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_count_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->count(); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_min_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->min(); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_max_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->max(); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_collect_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->collect(new Collector(
       function() { return 0; },
@@ -201,7 +201,7 @@ class SequenceTest extends AbstractSequenceTest {
     )); });
   }
 
-  #[Test, Values('util.data.unittest.Enumerables::streamedArrays')]
+  #[Test, Values(from: 'streamedArrays')]
   public function cannot_use_reduce_on_a_sequence_based_on_a_streamed_enumerable_twice($input) {
     $this->assertNotTwice(Sequence::of($input), function($seq) { $seq->reduce(
       0,

--- a/src/test/php/util/data/unittest/SequenceZipTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceZipTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 use util\data\Sequence;
 
 class SequenceZipTest extends AbstractSequenceTest {

--- a/src/test/php/util/data/unittest/TraversalOfTest.class.php
+++ b/src/test/php/util/data/unittest/TraversalOfTest.class.php
@@ -1,7 +1,7 @@
 <?php namespace util\data\unittest;
 
 use lang\IllegalStateException;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\data\{CannotReset, TraversalOf};
 
 class TraversalOfTest {

--- a/src/test/php/util/data/unittest/YieldingOfTest.class.php
+++ b/src/test/php/util/data/unittest/YieldingOfTest.class.php
@@ -1,6 +1,6 @@
 <?php namespace util\data\unittest;
 
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\data\{CannotReset, YieldingOf};
 
 class YieldingOfTest {
@@ -14,12 +14,12 @@ class YieldingOfTest {
     yield [function() { yield 'key' => 'value'; }, ['key' => 'value']];
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function iteration($generator, $expected) {
     Assert::equals($expected, iterator_to_array(new YieldingOf($generator())));
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function cannot_rewind_after_rewind($generator) {
     $fixture= new YieldingOf($generator());
     $fixture->rewind();
@@ -29,7 +29,7 @@ class YieldingOfTest {
     });
   }
 
-  #[Test, Values('fixtures')]
+  #[Test, Values(from: 'fixtures')]
   public function cannot_rewind_after_complete_iteration($generator) {
     $fixture= new YieldingOf($generator());
     iterator_to_array($fixture);


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Mostly migrated automatically, needed an adjustment for `#[Values(from: ...)]` not supporting `Type::method` syntax, adding missing imports as well as https://github.com/xp-framework/test/pull/15