### PR TITLE
Add `concat()`, returns a concatenation of the sequence and the given enumerable

### DIFF
--- a/src/main/php/util/data/Sequence.class.php
+++ b/src/main/php/util/data/Sequence.class.php
@@ -96,6 +96,22 @@ class Sequence implements Value, IteratorAggregate {
   }
 
   /**
+   * Creates a new stream with an enumeration of elements
+   *
+   * @param  ?iterable|util.XPIterator|function(): iterable $enumerable
+   * @return self
+   * @throws lang.IllegalArgumentException if type of elements argument is incorrect
+   */
+  public function concat($enumerable) {
+    $enumeration= Enumeration::of($enumerable);
+    $f= function() use($enumeration) {
+      yield from $this->elements;
+      yield from $enumeration;
+    };
+    return new self($f());
+  }
+
+  /**
    * Returns the first element of this stream, or an empty optional
    *
    * @param  util.Filter|function(var): bool $filter An optional filter

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -86,7 +86,7 @@ class SequenceCreationTest extends AbstractSequenceTest {
   public function concat_after_mapping() {
     $this->assertSequence(
       [2, 4, 6, 'EOF'],
-      Sequence::of([1, 2, 3])->map(fn($e) => $e * 2)->concat(['EOF'])
+      Sequence::of([1, 2, 3])->map(function($e) { return $e * 2; })->concat(['EOF'])
     );
   }
 

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -73,4 +73,17 @@ class SequenceCreationTest extends AbstractSequenceTest {
   public function multiple_arguments_supported_in_of(... $input) {
     $this->assertSequence([1, 2, 3, 4, 5, 6], Sequence::of(...$input));
   }
+
+  #[Test]
+  public function concat() {
+    $this->assertSequence(
+      [1, 2, 3, 4, 5, 6, 7, 8, 9],
+      Sequence::of([1, 2, 3])->concat([4, 5, 6])->concat([7, 8, 9])
+    );
+  }
+
+  #[Test, Expect(IllegalArgumentException::class)]
+  public function cannot_concat_non_enumerable() {
+    Sequence::$EMPTY->concat('test');
+  }
 }

--- a/src/test/php/util/data/unittest/SequenceCreationTest.class.php
+++ b/src/test/php/util/data/unittest/SequenceCreationTest.class.php
@@ -82,6 +82,14 @@ class SequenceCreationTest extends AbstractSequenceTest {
     );
   }
 
+  #[Test]
+  public function concat_after_mapping() {
+    $this->assertSequence(
+      [2, 4, 6, 'EOF'],
+      Sequence::of([1, 2, 3])->map(fn($e) => $e * 2)->concat(['EOF'])
+    );
+  }
+
   #[Test, Expect(IllegalArgumentException::class)]
   public function cannot_concat_non_enumerable() {
     Sequence::$EMPTY->concat('test');


### PR DESCRIPTION
## Example

```php
use util\data\Sequence;

Sequence::of([1, 2, 3])->concat([4, 5, 6])->toArray();  // [1, 2, 3, 4, 5, 6]
```

# See also:

* https://stackoverflow.com/questions/40161956/kotlin-sequence-concatenation
* https://www.baeldung.com/kotlin/flows-sequential-concatenation
* https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.concat